### PR TITLE
Fix AddFromAttributes() when a class has multiple ServiceDescriptorAttributes.

### DIFF
--- a/src/Scrutor/AttributeSelector.cs
+++ b/src/Scrutor/AttributeSelector.cs
@@ -20,18 +20,14 @@ namespace Scrutor
             {
                 var typeInfo = type.GetTypeInfo();
 
-                var attribute = typeInfo.GetCustomAttribute<ServiceDescriptorAttribute>();
-
-                if (attribute == null)
+                foreach (var attribute in typeInfo.GetCustomAttributes<ServiceDescriptorAttribute>())
                 {
-                    continue;
+                    var serviceType = attribute.ServiceType ?? type;
+
+                    var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
+
+                    services.Add(descriptor);
                 }
-
-                var serviceType = attribute.ServiceType ?? type;
-
-                var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
-
-                services.Add(descriptor);
             }
         }
     }

--- a/src/Scrutor/project.json
+++ b/src/Scrutor/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.3.1-*",
+    "version": "1.3.2-*",
 
     "description": "Register services using assembly scanning and a fluent API.",
     "authors": [ "Kristian Hellang" ],

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -99,6 +99,31 @@ namespace Scrutor.Tests
             Assert.Equal(typeof(TransientService1), service.ImplementationType);
         }
 
+        [Fact]
+        public void CanHandleMultipleAttributes()
+        {
+            var collection = new ServiceCollection();
+
+            collection.Scan(scan => scan.FromAssemblyOf<ITransientServiceToCombine>().AddFromAttributes());
+
+            var transientService = collection.GetDescriptor<ITransientServiceToCombine>();
+
+            Assert.NotNull(transientService);
+            Assert.Equal(ServiceLifetime.Transient, transientService.Lifetime);
+            Assert.Equal(typeof(CombinedService), transientService.ImplementationType);
+
+            var scopedService = collection.GetDescriptor<IScopedServiceToCombine>();
+
+            Assert.NotNull(scopedService);
+            Assert.Equal(ServiceLifetime.Scoped, scopedService.Lifetime);
+            Assert.Equal(typeof(CombinedService), scopedService.ImplementationType);
+
+            var singletonService = collection.GetDescriptor<ISingletonServiceToCombine>();
+
+            Assert.NotNull(singletonService);
+            Assert.Equal(ServiceLifetime.Singleton, singletonService.Lifetime);
+            Assert.Equal(typeof(CombinedService), singletonService.ImplementationType);
+        }
 
         [Fact]
         public void AutoRegisterAsMatchingInterface()
@@ -175,6 +200,15 @@ namespace Scrutor.Tests
     public class QueryHandler : IQueryHandler<string, int> { }
 
     public class BaseQueryHandler<T> : IQueryHandler<T, int> { }
+
+    public interface ITransientServiceToCombine { }
+    public interface IScopedServiceToCombine { }
+    public interface ISingletonServiceToCombine { }
+
+    [ServiceDescriptor(typeof(ITransientServiceToCombine))]
+    [ServiceDescriptor(typeof(IScopedServiceToCombine), ServiceLifetime.Scoped)]
+    [ServiceDescriptor(typeof(ISingletonServiceToCombine), ServiceLifetime.Singleton)]
+    public class CombinedService : ITransientServiceToCombine, IScopedServiceToCombine, ISingletonServiceToCombine { }
 }
 
 namespace UnwantedNamespace


### PR DESCRIPTION
Not only did that use case not work, scanning actually crashed with an AmbiguousMatchException.