### PR TITLE
Validate whether a ServiceDescriptorAttribute has an invalid ServiceType

### DIFF
--- a/src/Scrutor/AttributeSelector.cs
+++ b/src/Scrutor/AttributeSelector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,9 +21,17 @@ namespace Scrutor
             {
                 var typeInfo = type.GetTypeInfo();
 
-                foreach (var attribute in typeInfo.GetCustomAttributes<ServiceDescriptorAttribute>())
+                var attributes = typeInfo.GetCustomAttributes<ServiceDescriptorAttribute>().ToArray();
+                // check whether they have the same service type
+                var duplicates = attributes.GroupBy(s => s).SelectMany(grp => grp.Skip(1));
+                if (duplicates.Any())
                 {
-                    var serviceType = attribute.ServiceType ?? type;
+                    throw new InvalidOperationException($"Type \"{type.FullName}\" has multiple ServiceDescriptors specified with the same service type.");
+                }
+
+                foreach (var attribute in attributes)
+                {
+                    var serviceType = GetServiceType(type, attribute);
 
                     var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
 
@@ -30,5 +39,23 @@ namespace Scrutor
                 }
             }
         }
+
+        private Type GetServiceType(Type type, ServiceDescriptorAttribute attribute)
+        {
+            var serviceType = attribute.ServiceType;
+            if (ReferenceEquals(null, serviceType))
+            {
+                return type;
+            }
+
+            if (!serviceType.IsAssignableFrom(type))
+            {
+                throw new InvalidOperationException($"Type \"{type.FullName}\" does not inherit or implement \"${serviceType}\".");
+            }
+
+            return serviceType;
+
+        }
+
     }
 }

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -82,9 +82,19 @@ namespace Scrutor.Tests
         [Fact]
         public void CanScanUsingAttributes()
         {
-            Collection.Scan(scan => scan.FromAssemblyOf<ITransientService>().AddFromAttributes());
+            var interfaces = new []
+                {
+                    typeof(ITransientService),
+                    typeof(ITransientServiceToCombine),
+                    typeof(IScopedServiceToCombine),
+                    typeof(ISingletonServiceToCombine),
 
-            Assert.Equal(Collection.Count, 4);
+                };
+            Collection.Scan(scan => scan.FromAssemblyOf<ITransientService>()
+                    .AddFromAttributes(t => t.AssignableToAny(interfaces)));
+
+
+            Assert.Equal(4, Collection.Count);
 
             var service = Collection.GetDescriptor<ITransientService>();
 
@@ -111,7 +121,8 @@ namespace Scrutor.Tests
         [Fact]
         public void CanHandleMultipleAttributes()
         {
-            Collection.Scan(scan => scan.FromAssemblyOf<ITransientServiceToCombine>().AddFromAttributes());
+            Collection.Scan(scan => scan.FromAssemblyOf<ITransientServiceToCombine>()
+                .AddFromAttributes(t => t.AssignableTo<ITransientServiceToCombine>()));
 
             var transientService = Collection.GetDescriptor<ITransientServiceToCombine>();
 


### PR DESCRIPTION
We had some cases where we had wrong ServiceType registered due copy&paste error. This should now throw an exception for this cases.

Not sure whether there is a better way to test this implementation than adding a new project.