### PR TITLE
Create default ServiceDescriptors in case no ServiceDescriptorAttribute.ServiceType is set.

### DIFF
--- a/src/Scrutor/AttributeSelector.cs
+++ b/src/Scrutor/AttributeSelector.cs
@@ -40,22 +40,27 @@ namespace Scrutor
 
                 foreach (var attribute in attributes)
                 {
-                    var serviceType = GetServiceType(type, attribute);
+                    var serviceTypes = GetServiceType(type, attribute);
 
-                    var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
+                    foreach (var serviceType in serviceTypes)
+                    {
+                        var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
 
-                    services.Add(descriptor);
+                        services.Add(descriptor);
+                    }
                 }
             }
         }
 
-        private static Type GetServiceType(Type type, ServiceDescriptorAttribute attribute)
+        private static IEnumerable<Type> GetServiceType(Type type, ServiceDescriptorAttribute attribute)
         {
             var serviceType = attribute.ServiceType;
 
-            if (serviceType == null)
+            if (serviceType==null)
             {
-                return type;
+                return type.GetInterfaces()
+                    .Concat(new [] {type, type.GetTypeInfo().BaseType})
+                        .Except(new [] {typeof(Object), null});
             }
 
             if (!serviceType.IsAssignableFrom(type))
@@ -63,7 +68,7 @@ namespace Scrutor
                 throw new InvalidOperationException($@"Type ""{type.FullName}"" is not assignable to ""${serviceType.FullName}"".");
             }
 
-            return serviceType;
+            return new [] { serviceType };
         }
     }
 }

--- a/src/Scrutor/AttributeSelector.cs
+++ b/src/Scrutor/AttributeSelector.cs
@@ -56,7 +56,7 @@ namespace Scrutor
         {
             var serviceType = attribute.ServiceType;
 
-            if (serviceType==null)
+            if (serviceType == null)
             {
                 return type.GetInterfaces()
                     .Concat(new [] {type, type.GetTypeInfo().BaseType})

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Scrutor.Tests;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Scrutor.Tests
@@ -119,6 +120,28 @@ namespace Scrutor.Tests
             Assert.NotNull(service);
             Assert.Equal(ServiceLifetime.Transient, service.Lifetime);
             Assert.Equal(typeof(TransientService1), service.ImplementationType);
+        }
+
+        [Fact]
+        public void CanCreateDefault()
+        {
+            var types = new[]
+            {
+                typeof(IDefault1),
+                typeof(IDefault2),
+                typeof(IDefault3),
+                typeof(Default3)
+            };
+
+            Collection.Scan(scan => scan.FromAssemblyOf<ITransientService>()
+                .AddClasses(t => t.AssignableToAny(types))
+                    .UsingAttributes());
+
+            Assert.Equal(5, Collection.Count);
+            var remainingSetOfTypes = Collection.Select(descriptor => descriptor.ServiceType)
+                .Except(types.Concat(new[] {typeof(DefaultAttributes)}));
+            Assert.Equal(0, remainingSetOfTypes.Count());
+
         }
 
         [Fact]
@@ -270,6 +293,17 @@ namespace Scrutor.Tests
     [ServiceDescriptor(typeof(IDuplicateInheritance))]
     [ServiceDescriptor(typeof(IDuplicateInheritance))]
     public class DuplicateInheritance : IDuplicateInheritance, IOtherInheritance { }
+    
+    public interface IDefault1 {}
+
+    public interface IDefault2 {}
+
+    public interface IDefault3 {}
+
+    public interface Default3 : IDefault3 { }
+
+    [ServiceDescriptor]
+    public class DefaultAttributes : Default3, IDefault1, IDefault2 {}
 }
 
 namespace UnwantedNamespace

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -144,7 +144,7 @@ namespace Scrutor.Tests
                     .AddClasses(t => t.AssignableTo<IDuplicateInheritance>())
                         .UsingAttributes()));
 
-            Assert.Equal("Type \"Scrutor.Tests.DuplicateInheritance\" has multiple ServiceDescriptor attributes with the same service type.", ex.Message);
+            Assert.Equal($@"Type ""Scrutor.Tests.DuplicateInheritance"" has multiple ServiceDescriptor attributes with the same service type.", ex.Message);
         }
 
         [Fact]

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -134,7 +134,7 @@ namespace Scrutor.Tests
             };
 
             Collection.Scan(scan => scan.FromAssemblyOf<ITransientService>()
-                .AddClasses(t => t.AssignableToAny(types))
+                .AddClasses(t => t.AssignableTo<DefaultAttributes>())
                     .UsingAttributes());
 
             Assert.Equal(5, Collection.Count);


### PR DESCRIPTION
Create default service descriptors for this use case:
```cs
public class ServiceBase : IService
[ServiceDescriptor]
public class MyService : ServiceBase, IService1 {}
```
This will create 4 service descriptors:
- MyService
- ServiceBase
- IService
- IService1

According to the discussion in https://github.com/khellang/Scrutor/pull/9/files/eab865333b910765b04dda76763d1da771e24066#diff-e2a2358172ac5f8df9f098e70316dd0dR178

This replaces the default behavior where only the current type was added as service descriptor.