### PR TITLE
Move extensions under ms namespace

### DIFF
--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
 
-namespace Scrutor
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class ServiceCollectionExtensions
     {

--- a/src/Scrutor/ServiceCollectionExtensions.Scanning.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Scanning.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
 
-namespace Scrutor
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class ServiceCollectionExtensions
     {


### PR DESCRIPTION
closes #15 

~I avoided to flag extensions under Scrutor namespace, because could cause warnings when using both namespace `Scrutor` and `Microsoft.Extensions.DependencyInjection`~

we can think to definitively move under MS namespace, or just leave as this PR for a while.