### PR TITLE
Added open generic support to decoration

### DIFF
--- a/src/Scrutor/ReflectionExtensions.cs
+++ b/src/Scrutor/ReflectionExtensions.cs
@@ -227,5 +227,11 @@ namespace Scrutor
 
             return true;
         }
+
+        public static bool IsOpenGeneric(this Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.IsGenericTypeDefinition;
+        }
     }
 }

--- a/test/Scrutor.Tests/DecorationTests.cs
+++ b/test/Scrutor.Tests/DecorationTests.cs
@@ -119,6 +119,7 @@ namespace Scrutor.Tests
             Assert.Same(validator, decorator.InjectedService);
         }
 
+
         private static IServiceProvider ConfigureProvider(Action<IServiceCollection> configure)
         {
             var services = new ServiceCollection();

--- a/test/Scrutor.Tests/OpenGenericDecorationTests.cs
+++ b/test/Scrutor.Tests/OpenGenericDecorationTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Scrutor.Tests
+{
+    public class OpenGenericDecorationTests
+    {
+        private IServiceCollection Collection { get; } = new ServiceCollection();
+
+        private static IServiceProvider ConfigureProvider(Action<IServiceCollection> configure)
+        {
+            var services = new ServiceCollection();
+
+            configure(services);
+
+            return services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void CanDecorateOpenGenericTypeBasedOnClass()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<QueryHandler<MyQuery, MyResult>, MyQueryHandler>();
+                services.Decorate(typeof(QueryHandler<,>), typeof(LoggingQueryHandler<,>));
+                services.Decorate(typeof(QueryHandler<,>), typeof(TelemetryQueryHandler<,>));
+            });
+
+            var instance = provider.GetRequiredService<QueryHandler<MyQuery, MyResult>>();
+
+            var telemetryDecorator = Assert.IsType<TelemetryQueryHandler<MyQuery, MyResult>>(instance);
+            var loggingDecorator = Assert.IsType<LoggingQueryHandler<MyQuery, MyResult>>(telemetryDecorator.Inner);
+            Assert.IsType<MyQueryHandler>(loggingDecorator.Inner);
+        }
+
+
+        [Fact]
+        public void CanDecorateOpenGenericTypeBasedOnInterface()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<IQueryHandler<MyQuery,MyResult>, MyQueryHandler>();
+                services.Decorate(typeof(IQueryHandler<,>), typeof(LoggingQueryHandler<,>));
+                services.Decorate(typeof(IQueryHandler<,>), typeof(TelemetryQueryHandler<,>));
+            });
+
+            var instance = provider.GetRequiredService<IQueryHandler<MyQuery, MyResult>>();
+
+            var telemetryDecorator = Assert.IsType<TelemetryQueryHandler<MyQuery, MyResult>>(instance);
+            var loggingDecorator = Assert.IsType<LoggingQueryHandler<MyQuery, MyResult>>(telemetryDecorator.Inner);
+            Assert.IsType<MyQueryHandler>(loggingDecorator.Inner);
+        }
+    }
+
+    public class MyQuery
+    {
+        
+    }
+
+    public class MyResult
+    {
+        
+    }
+
+    public class MyQueryHandler : QueryHandler<MyQuery, MyResult>
+    {
+    }
+
+
+    public class QueryHandler<TQuery, TResult> : IQueryHandler<TQuery, TResult>
+    {
+        
+    }
+
+    public class LoggingQueryHandler<TQuery, TResult> : DecoratorQueryHandler<TQuery, TResult>
+    {
+        public LoggingQueryHandler(IQueryHandler<TQuery, TResult> inner) : base(inner)
+        {
+        }
+
+    }
+
+
+    public class TelemetryQueryHandler<TQuery, TResult> : DecoratorQueryHandler<TQuery, TResult>
+    {
+        public TelemetryQueryHandler(IQueryHandler<TQuery, TResult> inner) : base(inner)
+        {
+        }
+
+    }
+
+
+    public class DecoratorQueryHandler<TQuery, TResult> :QueryHandler<TQuery, TResult>,  IDecoratorQueryHandler<TQuery, TResult>
+    {
+        public DecoratorQueryHandler(IQueryHandler<TQuery, TResult> inner)
+        {
+            Inner = inner;
+        }
+
+        public IQueryHandler<TQuery, TResult> Inner { get; }
+    }
+
+    public interface IDecoratorQueryHandler<TQuery, TResult> : IQueryHandler<TQuery, TResult>
+    {
+        IQueryHandler<TQuery, TResult> Inner { get; }
+    }
+}


### PR DESCRIPTION
Hi Kristian,

I have added support for Open Generic Decorators that should close off issue #14 .

I have taken an approach where I look for existing closed types in the ServiceCollection based on the open generic service type and then use the existing closed type parameters to create a closed generic type which can  be registered like a normal decorator.

The usage is like this:

services.AddSingleton<QueryHandler<MyQuery, MyResult>, MyQueryHandler>();
services.Decorate(typeof(QueryHandler<,>), typeof(LoggingQueryHandler<,>));
services.Decorate(typeof(QueryHandler<,>), typeof(TelemetryQueryHandler<,>));

I have added some unit tests to prove it works. It would be great if this could be added to your library.

Cheers
Nick