### PR TITLE
Make AddClasses() only include public classes

### DIFF
--- a/src/Scrutor/ImplementationTypeSelector.cs
+++ b/src/Scrutor/ImplementationTypeSelector.cs
@@ -16,7 +16,7 @@ namespace Scrutor
 
         public IServiceTypeSelector AddClasses()
         {
-            return AddClasses(publicOnly: false);
+            return AddClasses(publicOnly: true);
         }
 
         public IServiceTypeSelector AddClasses(bool publicOnly)


### PR DESCRIPTION
The documentation for `AddClasses()` at https://github.com/khellang/Scrutor/blob/master/src/Scrutor/IImplementationTypeSelector.cs#L8 says "Adds all *public*, non-abstract classes". However, the implementation seems to do the opposite, by passing in `false` as the `publicOnly` parameter. This fix passes in `true` instead.