### PR TITLE
Change IAssemblySelector interface  to get the matching assembly.

### DIFF
--- a/src/Scrutor/IAssemblySelector.cs
+++ b/src/Scrutor/IAssemblySelector.cs
@@ -34,7 +34,9 @@ namespace Scrutor
         /// If loading <see cref="DependencyContext.Default"/> fails, this method will fall back to calling <see cref="FromApplicationDependencies"/>,
         /// using the entry assembly.
         /// </summary>
-        IImplementationTypeSelector FromApplicationDependencies();
+        /// <param name="predicate">The predicate to match assemblys.</param>
+        IImplementationTypeSelector FromApplicationDependencies(
+            Func<Assembly, bool> predicate = null);
 
         /// <summary>
         /// Will load and scan all runtime libraries referenced by the currently specified <paramref name="assembly"/>.
@@ -46,7 +48,9 @@ namespace Scrutor
         /// Will load and scan all runtime libraries in the given <paramref name="context"/>.
         /// </summary>
         /// <param name="context">The dependency context.</param>
-        IImplementationTypeSelector FromDependencyContext(DependencyContext context);
+        /// <param name="predicate">The predicate to match assemblys.</param>
+        IImplementationTypeSelector FromDependencyContext(
+            DependencyContext context, Func<Assembly, bool> predicate = null);
 #endif
 
         /// <summary>

--- a/src/Scrutor/ImplementationTypeSelector.cs
+++ b/src/Scrutor/ImplementationTypeSelector.cs
@@ -74,9 +74,10 @@ namespace Scrutor
             return Inner.FromEntryAssembly();
         }
 
-        public IImplementationTypeSelector FromApplicationDependencies()
+        public IImplementationTypeSelector 
+            FromApplicationDependencies(Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromApplicationDependencies();
+            return Inner.FromApplicationDependencies(predicate);
         }
 
         public IImplementationTypeSelector FromAssemblyDependencies(Assembly assembly)
@@ -84,9 +85,10 @@ namespace Scrutor
             return Inner.FromAssemblyDependencies(assembly);
         }
 
-        public IImplementationTypeSelector FromDependencyContext(DependencyContext context)
+        public IImplementationTypeSelector FromDependencyContext(
+            DependencyContext context, Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromDependencyContext(context);
+            return Inner.FromDependencyContext(context, predicate);
         }
 #endif
 

--- a/src/Scrutor/LifetimeSelector.cs
+++ b/src/Scrutor/LifetimeSelector.cs
@@ -66,9 +66,10 @@ namespace Scrutor
             return Inner.FromEntryAssembly();
         }
 
-        public IImplementationTypeSelector FromApplicationDependencies()
+        public IImplementationTypeSelector
+            FromApplicationDependencies(Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromApplicationDependencies();
+            return Inner.FromApplicationDependencies(predicate);
         }
 
         public IImplementationTypeSelector FromAssemblyDependencies(Assembly assembly)
@@ -76,9 +77,10 @@ namespace Scrutor
             return Inner.FromAssemblyDependencies(assembly);
         }
 
-        public IImplementationTypeSelector FromDependencyContext(DependencyContext context)
+        public IImplementationTypeSelector FromDependencyContext(
+            DependencyContext context, Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromDependencyContext(context);
+            return Inner.FromDependencyContext(context, predicate);
         }
 #endif
 

--- a/src/Scrutor/ServiceTypeSelector.cs
+++ b/src/Scrutor/ServiceTypeSelector.cs
@@ -109,9 +109,10 @@ namespace Scrutor
             return Inner.FromEntryAssembly();
         }
 
-        public IImplementationTypeSelector FromApplicationDependencies()
+        public IImplementationTypeSelector 
+            FromApplicationDependencies(Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromApplicationDependencies();
+            return Inner.FromApplicationDependencies(predicate);
         }
 
         public IImplementationTypeSelector FromAssemblyDependencies(Assembly assembly)
@@ -119,9 +120,10 @@ namespace Scrutor
             return Inner.FromAssemblyDependencies(assembly);
         }
 
-        public IImplementationTypeSelector FromDependencyContext(DependencyContext context)
+        public IImplementationTypeSelector FromDependencyContext(
+            DependencyContext context, Func<Assembly, bool> predicate = null)
         {
-            return Inner.FromDependencyContext(context);
+            return Inner.FromDependencyContext(context, predicate);
         }
 #endif
 


### PR DESCRIPTION
Modify the FromApplicationDependencies method and the FromDependencyContext method in the IAssemblySelector interface, add the 'Func <Assembly, bool> predicate' parameter to get the matching assembly.