### PR TITLE
Add support for registering all interfaces against a single implementation

### DIFF
--- a/src/Scrutor/IServiceTypeSelector.cs
+++ b/src/Scrutor/IServiceTypeSelector.cs
@@ -37,6 +37,11 @@ namespace Scrutor
         ILifetimeSelector AsImplementedInterfaces();
 
         /// <summary>
+        /// Registers each matching concrete type as all of its implemented interfaces, by returning an instance of the main type
+        /// </summary>
+        ILifetimeSelector AsSelfWithInterfaces();
+
+        /// <summary>
         /// Registers the type with the first found matching interface name.  (e.g. ClassName is matched to IClassName)
         /// </summary>
         ILifetimeSelector AsMatchingInterface();

--- a/src/Scrutor/LifetimeSelector.cs
+++ b/src/Scrutor/LifetimeSelector.cs
@@ -11,15 +11,18 @@ namespace Scrutor
 {
     internal sealed class LifetimeSelector : ILifetimeSelector, ISelector
     {
-        public LifetimeSelector(IServiceTypeSelector inner, IEnumerable<TypeMap> typeMaps)
+        public LifetimeSelector(IServiceTypeSelector inner, IEnumerable<TypeMap> typeMaps, IEnumerable<TypeFactoryMap> typeFactoryMaps)
         {
             Inner = inner;
             TypeMaps = typeMaps;
+            TypeFactoryMaps = typeFactoryMaps;
         }
 
         private IServiceTypeSelector Inner { get; }
 
         private IEnumerable<TypeMap> TypeMaps { get; }
+
+        private IEnumerable<TypeFactoryMap> TypeFactoryMaps { get; }
 
         private ServiceLifetime? Lifetime { get; set; }
 
@@ -162,6 +165,11 @@ namespace Scrutor
             return Inner.AsImplementedInterfaces();
         }
 
+        public ILifetimeSelector AsSelfWithInterfaces()
+        {
+            return Inner.AsSelfWithInterfaces();
+        }
+
         public ILifetimeSelector AsMatchingInterface()
         {
             return Inner.AsMatchingInterface();
@@ -210,6 +218,16 @@ namespace Scrutor
                     }
 
                     var descriptor = new ServiceDescriptor(serviceType, implementationType, Lifetime.Value);
+
+                    strategy.Apply(services, descriptor);
+                }
+            }
+
+            foreach (var typeFactoryMap in TypeFactoryMaps)
+            {
+                foreach (var serviceType in typeFactoryMap.ServiceTypes)
+                {
+                    var descriptor = new ServiceDescriptor(serviceType, typeFactoryMap.ImplementationFactory, Lifetime.Value);
 
                     strategy.Apply(services, descriptor);
                 }

--- a/src/Scrutor/TypeFactoryMap.cs
+++ b/src/Scrutor/TypeFactoryMap.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Scrutor
+{
+    internal struct TypeFactoryMap
+    {
+        public TypeFactoryMap(Func<IServiceProvider, object> implementationFactory, IEnumerable<Type> serviceTypes)
+        {
+            ImplementationFactory = implementationFactory;
+            ServiceTypes = serviceTypes;
+        }
+
+        public Func<IServiceProvider, object> ImplementationFactory { get; }
+
+        public IEnumerable<Type> ServiceTypes { get; }
+    }
+}


### PR DESCRIPTION
Addresses #57

Added an alternative registration extension method `AsSelfWithInterfaces()` that registers the type itself, and all interfaces it implements, by forwarding the interface request to the concrete type. 

Added unit tests for this case, as well as confirming the existing behaviour with `AsSelf()` and `AsImplementedInterfaces()`.

This was my first look at the Scrutor code - any suggestions gladly accepted 🙂  