### PR TITLE
New extension: `AddComposite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ services.AddComposite<IReporter, CompositeReporter>();
 // Now when we resolve IReporter we'll get an instance of the composite.
 var serviceProvider = collection.BuildServiceProvider();
 var instance = serviceProvider.GetRequiredService<IReporter>();
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Scrutor - I search or examine thoroughly; I probe, investigate or scrutinize  
 > From scrūta, as the original sense of the verb was to search through trash. - https://en.wiktionary.org/wiki/scrutor
 
-Assembly scanning and decoration extensions for Microsoft.Extensions.DependencyInjection
+Assembly scanning, decoration and composition extensions for Microsoft.Extensions.DependencyInjection
 
 ## Installation
 
@@ -23,10 +23,11 @@ dotnet add package Scrutor
 
 ## Usage
 
-The library adds two extension methods to `IServiceCollection`:
+The library adds three extension methods to `IServiceCollection`:
 
 * `Scan` - This is the entry point to set up your assembly scanning.
-* `Decorate` - This method is used to decorate already registered services.
+* `Decorate` - This method is used to decorate already-registered services.
+* `AddComposite` - This method is used to compose already-registered services.
 
 See **Examples** below for usage examples.
 
@@ -87,3 +88,22 @@ var serviceProvider = collection.BuildServiceProvider();
 // OtherDecorator -> Decorator -> Decorated
 var instance = serviceProvider.GetRequiredService<IDecoratedService>();
 ```
+
+### Composite Pattern
+
+```csharp
+
+var services = new ServiceCollection();
+
+// Register any implementations of the service as needed
+services.AddSingleton<IReporter, ConsoleReporter>();
+services.AddScoped<IReporter, TelemetryReporter>();
+services.AddTransient<IReporter, EmailReporter>();
+
+// Then register your composite pattern implementation that can construct
+// on IEnumerable<IReporter>
+services.AddComposite<IReporter, CompositeReporter>();
+
+// Now when we resolve IReporter we'll get an instance of the composite.
+var serviceProvider = collection.BuildServiceProvider();
+var instance = serviceProvider.GetRequiredService<IReporter>();

--- a/src/Scrutor/ServiceCollectionExtensions.Composite.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Composite.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
           where TService : class
           where TImplementation : class, TService
         {
-            var wrappedDescriptors = services.Where(s => s.ServiceType == typeof(TService)).ToList();
+            var wrappedDescriptors = services.Where(s => typeof(TService).IsAssignableFrom(s.ServiceType)).ToList();
             foreach (var descriptor in wrappedDescriptors)
                 services.Remove(descriptor);
 

--- a/src/Scrutor/ServiceCollectionExtensions.Composite.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Composite.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers <typeparamref name="TConcrete"/> as a composite that wraps all
+        /// existing registrations of <typeparamref name="TInterface"/>.
+        /// </summary>
+        /// <typeparam name="TInterface"></typeparam>
+        /// <typeparam name="TConcrete"></typeparam>
+        /// <param name="services"></param>
+        public static void AddComposite<TInterface, TConcrete>(this IServiceCollection services)
+          where TInterface : class
+          where TConcrete : class, TInterface
+        {
+            var wrappedDescriptors = services.Where(s => s.ServiceType == typeof(TInterface)).ToList();
+            foreach (var descriptor in wrappedDescriptors)
+                services.Remove(descriptor);
+
+            var objectFactory = ActivatorUtilities.CreateFactory(
+              typeof(TConcrete),
+              new[] { typeof(IEnumerable<TInterface>) });
+
+            var maxWrappedServiceLifetime = wrappedDescriptors
+                .Select(d => d.Lifetime)
+                .DefaultIfEmpty(ServiceLifetime.Scoped)
+                .Max();
+
+            services.Add(ServiceDescriptor.Describe(
+              typeof(TInterface),
+              s => (TInterface)objectFactory(s, new[] { wrappedDescriptors.Select(d => s.CreateInstance(d)).Cast<TInterface>() }),
+              maxWrappedServiceLifetime)
+            );
+        }
+
+        private static object CreateInstance(this IServiceProvider services, ServiceDescriptor descriptor)
+        {
+            if (descriptor.ImplementationInstance != null)
+                return descriptor.ImplementationInstance;
+
+            if (descriptor.ImplementationFactory != null)
+                return descriptor.ImplementationFactory(services);
+
+            return ActivatorUtilities.GetServiceOrCreateInstance(services, descriptor.ImplementationType);
+        }
+    }
+}

--- a/src/Scrutor/ServiceCollectionExtensions.Composite.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Composite.cs
@@ -33,20 +33,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Add(ServiceDescriptor.Describe(
               typeof(TInterface),
-              s => (TInterface)objectFactory(s, new[] { wrappedDescriptors.Select(d => s.CreateInstance(d)).Cast<TInterface>() }),
+              s => (TInterface)objectFactory(s, new[] { wrappedDescriptors.Select(d => s.GetInstance(d)).Cast<TInterface>() }),
               maxWrappedServiceLifetime)
             );
-        }
-
-        private static object CreateInstance(this IServiceProvider services, ServiceDescriptor descriptor)
-        {
-            if (descriptor.ImplementationInstance != null)
-                return descriptor.ImplementationInstance;
-
-            if (descriptor.ImplementationFactory != null)
-                return descriptor.ImplementationFactory(services);
-
-            return ActivatorUtilities.GetServiceOrCreateInstance(services, descriptor.ImplementationType);
         }
     }
 }

--- a/test/Scrutor.Tests/CompositeTests.cs
+++ b/test/Scrutor.Tests/CompositeTests.cs
@@ -16,7 +16,7 @@ namespace Scrutor.Tests
                 services.AddSingleton<IService, Service1>();
                 services.AddSingleton<IService, Service2>();
 
-                services.AddComposite<IService, Composite>();
+                services.AddComposite<IService, Composite>(ServiceLifetime.Transient);
             });
 
             var instance = provider.GetRequiredService<IService>();
@@ -33,7 +33,7 @@ namespace Scrutor.Tests
         {
             var provider = ConfigureProvider(services =>
             {
-                services.AddComposite<IService, Composite>();
+                services.AddComposite<IService, Composite>(ServiceLifetime.Transient);
             });
 
             var instance = provider.GetRequiredService<IService>();
@@ -53,7 +53,7 @@ namespace Scrutor.Tests
                 services.AddSingleton<IService, Service2>();
                 services.AddSingleton<IOtherDependency, OtherDependency>();
 
-                services.AddComposite<IService, CompositeWithOtherDependency>();
+                services.AddComposite<IService, CompositeWithOtherDependency>(ServiceLifetime.Transient);
             });
 
             var instance = provider.GetRequiredService<IService>();
@@ -66,19 +66,6 @@ namespace Scrutor.Tests
         }
 
         [Fact]
-        public void CanComposeMultipleLifetimeScopes()
-        {
-            var services = new ServiceCollection();
-            services.AddScoped<IService, Service1>();
-            services.AddTransient<IService, Service2>();
-
-            services.AddComposite<IService, Composite>();
-
-            var descriptor = services.GetDescriptor<IService>();
-            Assert.Equal(ServiceLifetime.Transient, descriptor.Lifetime);
-        }
-
-        [Fact]
         public void CanComposeExtensionsOfComposedInterface()
         {
             var provider = ConfigureProvider(services =>
@@ -86,7 +73,7 @@ namespace Scrutor.Tests
                 services.AddSingleton<IService, Service1>();
                 services.AddSingleton<IExtendedService, ExtendedService1>();
 
-                services.AddComposite<IService, Composite>();
+                services.AddComposite<IService, Composite>(ServiceLifetime.Transient);
             });
 
             var instance = provider.GetRequiredService<IService>();

--- a/test/Scrutor.Tests/CompositeTests.cs
+++ b/test/Scrutor.Tests/CompositeTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using System.Linq;
+
+namespace Scrutor.Tests
+{
+    public class CompositeTests : TestBase
+    {
+        [Fact]
+        public void CanComposeTypes()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<IService, Service1>();
+                services.AddSingleton<IService, Service2>();
+
+                services.AddComposite<IService, Composite>();
+            });
+
+            var instance = provider.GetRequiredService<IService>();
+
+            var composite = Assert.IsType<Composite>(instance);
+
+            Assert.Equal("one,two", composite.GetMessage());
+            Assert.IsType<Service1>(composite.ConcreteServices[0]);
+            Assert.IsType<Service2>(composite.ConcreteServices[1]);
+        }
+
+        [Fact]
+        public void CanComposeWhenNoTypesRegistered()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddComposite<IService, Composite>();
+            });
+
+            var instance = provider.GetRequiredService<IService>();
+
+            var composite = Assert.IsType<Composite>(instance);
+
+            Assert.Equal(string.Empty, composite.GetMessage());
+            Assert.Equal(0, composite.ConcreteServices.Count);
+        }
+
+        [Fact]
+        public void CompositeTypeCanHaveOtherInjectedDependencies()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<IService, Service1>();
+                services.AddSingleton<IService, Service2>();
+                services.AddSingleton<IOtherDependency, OtherDependency>();
+
+                services.AddComposite<IService, CompositeWithOtherDependency>();
+            });
+
+            var instance = provider.GetRequiredService<IService>();
+
+            var composite = Assert.IsType<CompositeWithOtherDependency>(instance);
+
+            Assert.Equal("Prefix: one,two", composite.GetMessage());
+            Assert.IsType<Service1>(composite.ConcreteServices[0]);
+            Assert.IsType<Service2>(composite.ConcreteServices[1]);
+        }
+
+        [Fact]
+        public void CanComposeMultipleLifetimeScopes()
+        {
+            var services = new ServiceCollection();
+            services.AddScoped<IService, Service1>();
+            services.AddTransient<IService, Service2>();
+
+            services.AddComposite<IService, Composite>();
+
+            var descriptor = services.GetDescriptor<IService>();
+            Assert.Equal(ServiceLifetime.Transient, descriptor.Lifetime);
+        }
+
+        interface IService
+        {
+            string GetMessage();
+        }
+
+        class Service1 : IService
+        {
+            public string GetMessage() => "one";
+        }
+
+        class Service2 : IService
+        {
+            public string GetMessage() => "two";
+        }
+
+        class Composite : IService
+        {
+            public Composite(IEnumerable<IService> concreteServices)
+            {
+                this.ConcreteServices = concreteServices.ToList();
+            }
+
+            public IList<IService> ConcreteServices { get; }
+
+            public virtual string GetMessage() => string.Join(",",
+                this.ConcreteServices.Select(s => s.GetMessage()));
+        }
+
+        interface IOtherDependency
+        {
+            string GetPrefix();
+        }
+
+        class OtherDependency : IOtherDependency
+        {
+            public string GetPrefix() => "Prefix:";
+        }
+
+        class CompositeWithOtherDependency : Composite
+        {
+            private readonly IOtherDependency otherDependency;
+
+            public CompositeWithOtherDependency(IEnumerable<IService> concreteServices, IOtherDependency otherDependency)
+                : base(concreteServices)
+            {
+                this.otherDependency = otherDependency;
+            }
+
+            public override string GetMessage() => $"{this.otherDependency.GetPrefix()} {base.GetMessage()}";
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of the composite pattern through a new `AddComposite` extension method.

This is taken from a [blog post](https://greatrexpectations.com/2018/11/07/composite-pattern-in-net-core-with-dependency-injection/) I wrote a while back which builds on my own fairly-similar decorator pattern implementation.

# Usage

## Class Structure
```csharp
interface IReporter {
  void WriteMessage(string message);
}

class ConsoleReporter : IReporter { /*...*/ }
class LogFileReporter : IReporter { /*...*/ }

class CompositeReporter : IReporter {
  public CompositeReporter(IEnumerable<IReporter> concreteReporters) {
    this.concreteReporters = concreteReporters;
  }

  public void WriteMessage(string message) {
    foreach (var reporter in this.concreteReporters)
      reporter.WriteMessage(message);
  }
}
```
## Registration

```csharp
var services = new ServiceCollection();

// Register any implementations of the service as needed
services.AddSingleton<IReporter, ConsoleReporter>();
services.AddSingleton<IReporter, LogFileReporter>();

// Then register your composite pattern implementation that can construct
// on IEnumerable<IReporter>
services.AddComposite<IReporter, CompositeReporter>();

// Now when we resolve IReporter we'll get an instance of the composite.
var serviceProvider = collection.BuildServiceProvider();
var instance = serviceProvider.GetRequiredService<IReporter>();
```

# Implementation Notes

- This wasn't original written for Scrutor so may not fully match the  coding standards etc.  Point me to where it needs changing and I'll sort it out.
- The name `AddComposite` doesn't quite fit with `Decorate` and `Scan` but I didn't love `Compose`.  Thoughts?  Better suggestions?
- It looks like that if `Decorate`-d services need other dependencies then they need to be manually managed.  `AddComposite` deals with this automatically (as could `Decorate` if desired - I wrote a bit about it [here](https://greatrexpectations.com/2018/10/25/decorators-in-net-core-with-dependency-injection/)) but I wasn't sure if this was a design decision on your part.  Easy enough to remove this if needed.
- I'm trying to best-guess an appropriate lifetime scope based on the existing dependencies.  Again, I'm open to alternative ideas here - this approach worked for me in a specific situation but may not be appropriate everywhere.