### PR TITLE
Pin AssemblyVersion in Scrutor.csproj.

### DIFF
--- a/src/Scrutor/Scrutor.csproj
+++ b/src/Scrutor/Scrutor.csproj
@@ -17,6 +17,8 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>../signing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <!-- Only increase this value in case of incompatible API changes. -->
+    <AssemblyVersion>3.0.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See #53 . AssemblyVersion should only ever increase in case of incompatible API changes. 

This allows people that use strong named assemblies to update to a newer version of this assembly as long as no incompatible changes are introduced and avoids the need for assembly redirects. 