### PR TITLE
Improved replacement for the decorator

### DIFF
--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -283,9 +283,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var index = services.IndexOf(descriptor);
 
                 // To avoid reordering descriptors, in case a specific order is expected.
-                services.Insert(index, decorator(descriptor));
-
-                services.Remove(descriptor);
+                services[index] = decorator(descriptor);
             }
 
             return true;


### PR DESCRIPTION
Method `Insert` invokes `Array.Copy` and method `Remove` invokes `IndexOf` and `Array.Copy`.
```csharp
var index = services.IndexOf(descriptor);
services.Insert(index, decorator(descriptor));
services.Remove(descriptor);
```
Since `IServiceCollection` is basicaly `IList<ServiceDescriptor>` we can user indexer to replace a service with a decorator.
```csharp
var index = services.IndexOf(descriptor);
services[index] = decorator(descriptor);
```