### PR TITLE
Add Aggregate extension method.

### DIFF
--- a/src/Scrutor/ServiceCollectionExtensions.Aggregation.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Aggregation.cs
@@ -1,0 +1,301 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Scrutor;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        public static IServiceCollection Aggregate<TService, TAggregator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+
+            return services.AggregateDescriptors(
+                typeof(TService),
+                descriptors => descriptors.Aggregate(typeof(TService), typeof(TAggregator), lifetime));
+        }
+
+        public static bool TryAggregate<TService, TAggregator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+
+            return services.TryAggregateDescriptors(
+                typeof(TService),
+                descriptors => descriptors.Aggregate(typeof(TService), typeof(TAggregator), lifetime));
+        }
+
+        public static IServiceCollection Aggregate<TService>(this IServiceCollection services, Func<IEnumerable<TService>, TService> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            return services.Aggregate<TService>((children, _) => aggregator(children), lifetime);
+        }
+
+        public static IServiceCollection Aggregate<TService>(this IServiceCollection services, Func<IEnumerable<TService>, IServiceProvider, TService> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(aggregator, nameof(aggregator));
+
+            return services.AggregateDescriptors(
+                typeof(TService),
+                descriptors => descriptors.Aggregate(
+                    typeof(TService),
+                    lifetime,
+                    (children, provider) => aggregator(children.Cast<TService>(), provider)));
+        }
+
+        public static bool TryAggregate<TService>(this IServiceCollection services, Func<IEnumerable<TService>, TService> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            return services.TryAggregate<TService>((children, _) => aggregator(children), lifetime);
+        }
+
+        public static bool TryAggregate<TService>(this IServiceCollection services, Func<IEnumerable<TService>, IServiceProvider, TService> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(aggregator, nameof(aggregator));
+
+            return services.TryAggregateDescriptors(
+                typeof(TService),
+                descriptors => descriptors.Aggregate(
+                    typeof(TService),
+                    lifetime,
+                    (children, provider) => aggregator(children.Cast<TService>(), provider)));
+        }
+
+        public static IServiceCollection Aggregate(this IServiceCollection services, Type serviceType, Type aggregatorType, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(serviceType, nameof(serviceType));
+            Preconditions.NotNull(aggregatorType, nameof(aggregatorType));
+
+            if (serviceType.IsOpenGeneric() && aggregatorType.IsOpenGeneric())
+            {
+                return services.AggregateOpenGeneric(serviceType, aggregatorType, lifetime);
+            }
+
+            return services.AggregateDescriptors(
+                serviceType,
+                descriptors => descriptors.Aggregate(serviceType, aggregatorType, lifetime));
+        }
+
+        public static bool TryAggregate(this IServiceCollection services, Type serviceType, Type aggregatorType, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(serviceType, nameof(serviceType));
+            Preconditions.NotNull(aggregatorType, nameof(aggregatorType));
+
+            if (serviceType.IsOpenGeneric() && aggregatorType.IsOpenGeneric())
+            {
+                return services.TryAggregateOpenGeneric(serviceType, aggregatorType, lifetime);
+            }
+
+            return services.TryAggregateDescriptors(
+                serviceType,
+                descriptors => descriptors.Aggregate(serviceType, aggregatorType, lifetime));
+        }
+
+        public static IServiceCollection Aggregate(this IServiceCollection services, Type serviceType, Func<IEnumerable<object>, object> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(serviceType, nameof(serviceType));
+            Preconditions.NotNull(aggregator, nameof(aggregator));
+
+            return services.AggregateDescriptors(serviceType, x => x.Aggregate(serviceType, lifetime, aggregator));
+        }
+
+        public static bool TryAggregate(this IServiceCollection services, Type serviceType, Func<IEnumerable<object>, object> aggregator, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(serviceType, nameof(serviceType));
+            Preconditions.NotNull(aggregator, nameof(aggregator));
+
+            return services.TryAggregateDescriptors(serviceType, x => x.Aggregate(serviceType, lifetime, aggregator));
+        }
+
+        private static IServiceCollection AggregateOpenGeneric(this IServiceCollection services, Type serviceType, Type aggregatorType, ServiceLifetime lifetime)
+        {
+            if (services.TryAggregateOpenGeneric(serviceType, aggregatorType, lifetime))
+            {
+                return services;
+            }
+
+            throw new MissingTypeRegistrationException(serviceType);
+        }
+
+        private static bool TryAggregateOpenGeneric(this IServiceCollection services, Type openGenericServiceType, Type openGenericAggregatorType, ServiceLifetime lifetime)
+        {
+            var descriptors = services
+                .Where(descriptor => descriptor.ServiceType.IsAssignableTo(openGenericServiceType))
+                .ToList();
+            if (descriptors.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var descriptor in descriptors)
+            {
+                services.Remove(descriptor);
+            }
+
+            var closedGenericArguments = descriptors
+                .Where(descriptor => !descriptor.ServiceType.IsOpenGeneric())
+                .Select(descriptor => descriptor.ServiceType.GenericTypeArguments)
+                .Distinct()
+                .ToList();
+            foreach (var arguments in closedGenericArguments)
+            {
+                var closedGenericDescriptors = descriptors
+                    .Where(descriptor => descriptor.ServiceType.IsOpenGeneric()
+                                         || descriptor.ServiceType.GenericTypeArguments.SequenceEqual(arguments));
+                var closedServiceType = openGenericServiceType.MakeGenericType(arguments);
+                var closedAggregatorType = openGenericAggregatorType.MakeGenericType(arguments);
+                var aggregatorDescriptor = closedGenericDescriptors.AggregateOpenGenerics(closedServiceType, closedAggregatorType, lifetime);
+                services.Add(aggregatorDescriptor);
+            }
+
+            //var openGenericDescriptors = descriptors
+            //    .Where(descriptor => descriptor.ServiceType.IsOpenGeneric())
+            //    .ToList();
+            //if (openGenericDescriptors.Count > 0)
+            //{
+            //    openGenericDescriptors.AggregateOpenGenerics(openGenericServiceType, openGenericAggregatorType, )
+            //}
+
+            return true;
+        }
+
+        private static IServiceCollection AggregateDescriptors(this IServiceCollection services, Type serviceType, Func<IEnumerable<ServiceDescriptor>, ServiceDescriptor> aggregator)
+        {
+            if (services.TryAggregateDescriptors(serviceType, aggregator))
+            {
+                return services;
+            }
+
+            throw new MissingTypeRegistrationException(serviceType);
+        }
+
+        private static bool TryAggregateDescriptors(this IServiceCollection services, Type serviceType, Func<IEnumerable<ServiceDescriptor>, ServiceDescriptor> aggregator)
+        {
+            if (!services.TryGetDescriptors(serviceType, out var descriptors))
+            {
+                return false;
+            }
+
+            foreach (var descriptor in descriptors)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.Add(aggregator(descriptors));
+
+            return true;
+        }
+
+        private static ServiceDescriptor Aggregate<TService>(this IEnumerable<ServiceDescriptor> descriptors, ServiceLifetime lifetime, Func<IEnumerable<TService>, TService> aggregator)
+        {
+            return descriptors.Aggregate<TService>(lifetime, (children, _) => aggregator(children));
+        }
+
+        private static ServiceDescriptor Aggregate<TService>(this IEnumerable<ServiceDescriptor> descriptors, ServiceLifetime lifetime, Func<IEnumerable<TService>, IServiceProvider, TService> aggregator)
+        {
+            return descriptors.Aggregate(typeof(TService), lifetime, (children, provider) => aggregator(children.Cast<TService>(), provider));
+        }
+
+        private static ServiceDescriptor Aggregate(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, Type aggregatorType, ServiceLifetime lifetime)
+        {
+            return descriptors.Aggregate(serviceType, lifetime, (children, provider) => provider.CreateInstance(aggregatorType, children));
+        }
+
+        private static ServiceDescriptor Aggregate(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, ServiceLifetime lifetime, Func<IEnumerable<object>, object> aggregator)
+        {
+            return descriptors.Aggregate(serviceType, lifetime, (children, _) => aggregator(children));
+        }
+
+        private static ServiceDescriptor Aggregate(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, ServiceLifetime lifetime, Func<IEnumerable<object>, IServiceProvider, object> aggregator)
+        {
+            return ServiceDescriptor.Describe(
+                serviceType,
+                provider => aggregator(provider.GetInstances(serviceType, descriptors), provider),
+                lifetime);
+        }
+
+        private static ServiceDescriptor AggregateOpenGenerics(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, Type aggregatorType, ServiceLifetime lifetime)
+        {
+            return descriptors.AggregateOpenGenerics(
+                serviceType,
+                lifetime,
+                (children, provider) => provider.CreateInstance(aggregatorType, children));
+        }
+
+        private static ServiceDescriptor AggregateOpenGenerics(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, ServiceLifetime lifetime, Func<IEnumerable<object>, IServiceProvider, object> aggregator)
+        {
+            return descriptors.AggregateOpenGenerics(serviceType, serviceType.GenericTypeArguments, lifetime, aggregator);
+        }
+
+        private static ServiceDescriptor AggregateOpenGenerics(this IEnumerable<ServiceDescriptor> descriptors, Type serviceType, Type[] genericTypeArguments, ServiceLifetime lifetime, Func<IEnumerable<object>, IServiceProvider, object> aggregator)
+        {
+            return ServiceDescriptor.Describe(
+                serviceType,
+                provider => aggregator(provider.GetOpenGenericInstances(serviceType, genericTypeArguments, descriptors), provider),
+                lifetime);
+        }
+
+        private static IEnumerable<object> GetInstances(this IServiceProvider provider, Type serviceType, IEnumerable<ServiceDescriptor> descriptors)
+        {
+            var instances = provider.GetInstances(descriptors);
+            var resultType = typeof(CastingEnumerable<>).MakeGenericType(serviceType);
+            return (IEnumerable<object>)Activator.CreateInstance(resultType, instances);
+        }
+
+        private static IEnumerable<object> GetOpenGenericInstances(this IServiceProvider provider, Type serviceType, Type[] genericTypeArguments, IEnumerable<ServiceDescriptor> descriptors)
+        {
+            var instances = provider.GetOpenGenericInstances(descriptors, genericTypeArguments);
+            var resultType = typeof(CastingEnumerable<>).MakeGenericType(serviceType);
+            return (IEnumerable<object>)Activator.CreateInstance(resultType, instances);
+        }
+
+        private static IEnumerable<object> GetInstances(this IServiceProvider provider, IEnumerable<ServiceDescriptor> descriptors)
+        {
+            return descriptors.Select(provider.GetInstance);
+        }
+
+        private static IEnumerable<object> GetOpenGenericInstances(this IServiceProvider provider, IEnumerable<ServiceDescriptor> descriptors, Type[] genericTypeArguments)
+        {
+            return descriptors.Select(descriptor => provider.GetOpenGenericInstance(descriptor, genericTypeArguments));
+        }
+
+        private static object GetOpenGenericInstance(this IServiceProvider provider, ServiceDescriptor descriptor, Type[] genericTypeArguments)
+        {
+            if (descriptor.ImplementationInstance != null)
+            {
+                return descriptor.ImplementationInstance;
+            }
+
+            if (descriptor.ImplementationType != null)
+            {
+                var implementationType = descriptor.ImplementationType.IsOpenGeneric()
+                    ? descriptor.ImplementationType.MakeGenericType(genericTypeArguments)
+                    : descriptor.ImplementationType;
+                return provider.GetServiceOrCreateInstance(implementationType);
+            }
+
+            return descriptor.ImplementationFactory(provider);
+        }
+
+        private class CastingEnumerable<T> : IEnumerable<T>
+        {
+            private readonly IEnumerable<T> _delegate;
+
+            public CastingEnumerable([NotNull] IEnumerable<object> @delegate)
+            {
+                _delegate = @delegate?.Cast<T>() ?? throw new ArgumentNullException(nameof(@delegate));
+            }
+
+            public IEnumerator<T> GetEnumerator() => _delegate.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/test/Scrutor.Tests/AggregationTests.cs
+++ b/test/Scrutor.Tests/AggregationTests.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Scrutor.Tests
+{
+    public class AggregationTests: TestBase
+    {
+        [Fact]
+        public void CanAggregateType()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<ICompositeService, LeafServiceA>();
+                services.AddTransient<ICompositeService, LeafServiceA>();
+                services.Aggregate<ICompositeService, CompositeService>();
+            });
+
+            var instance = provider.GetRequiredService<ICompositeService>();
+
+            var aggregator = Assert.IsType<CompositeService>(instance);
+
+            Assert.Equal(2, aggregator.AggregatedServices.Count());
+            Assert.All(aggregator.AggregatedServices, injectedService => Assert.IsType<LeafServiceA>(injectedService));
+        }
+
+        [Fact]
+        public void CanAggregateDifferentServices()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<ICompositeService, LeafServiceA>();
+                services.AddTransient<ICompositeService, LeafServiceB>();
+                services.Aggregate<ICompositeService, CompositeService>();
+            });
+
+            var instance = provider.GetRequiredService<ICompositeService>();
+
+            var aggregator = Assert.IsType<CompositeService>(instance);
+
+            Assert.Collection(aggregator.AggregatedServices,
+                injectedService => Assert.IsType<LeafServiceA>(injectedService),
+                injectedService => Assert.IsType<LeafServiceB>(injectedService));
+        }
+
+        [Fact]
+        public void CanAggregateExistingInstances()
+        {
+            var existingA = new LeafServiceA();
+            var existingB = new LeafServiceB();
+
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<ICompositeService>(existingA);
+                services.AddSingleton<ICompositeService>(existingB);
+                services.Aggregate<ICompositeService, CompositeService>();
+            });
+
+            var instance = provider.GetRequiredService<ICompositeService>();
+
+            var aggregator = Assert.IsType<CompositeService>(instance);
+
+            Assert.Collection(aggregator.AggregatedServices,
+                injectedService => Assert.Same(existingA, injectedService),
+                injectedService => Assert.Same(existingB, injectedService));
+        }
+
+        [Fact]
+        public void CanInjectServicesIntoAggregatedType()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<IService, SomeRandomService>();
+                services.AddTransient<ICompositeService, LeafServiceA>();
+                services.AddTransient<ICompositeService, LeafServiceB>();
+                services.Aggregate<ICompositeService, CompositeService>();
+            });
+
+            var validator = provider.GetRequiredService<IService>();
+
+            var instance = provider.GetRequiredService<ICompositeService>();
+
+            var aggregator = Assert.IsType<CompositeService>(instance);
+
+            Assert.Collection(aggregator.AggregatedServices,
+                injectedService =>
+                {
+                    var leafA = Assert.IsType<LeafServiceA>(injectedService);
+                    Assert.Same(validator, leafA.InjectedService);
+                },
+                injectedService =>
+                {
+                    var leafB = Assert.IsType<LeafServiceB>(injectedService);
+                    Assert.Same(validator, leafB.InjectedService);
+                });
+        }
+
+        [Fact]
+        public void CanInjectServicesIntoAggregatingType()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddSingleton<IService, SomeRandomService>();
+                services.AddTransient<ICompositeService, LeafServiceA>();
+                services.AddTransient<ICompositeService, LeafServiceB>();
+                services.Aggregate<ICompositeService, CompositeService>();
+            });
+
+            var validator = provider.GetRequiredService<IService>();
+
+            var instance = provider.GetRequiredService<ICompositeService>();
+
+            var aggregator = Assert.IsType<CompositeService>(instance);
+
+            Assert.Same(validator, aggregator.InjectedService);
+        }
+
+        [Fact]
+        public void DecoratingNonRegisteredServiceThrows()
+        {
+            Assert.Throws<MissingTypeRegistrationException>(() => ConfigureProvider(services => services.Decorate<ICompositeService, CompositeService>()));
+        }
+
+        public interface IService { }
+
+        private class SomeRandomService : IService { }
+
+        public interface ICompositeService { }
+
+        private class LeafServiceA : ICompositeService
+        {
+            public LeafServiceA(IService injectedService = null)
+            {
+                InjectedService = injectedService;
+            }
+
+            public IService InjectedService { get; }
+        }
+
+        private class LeafServiceB : ICompositeService
+        {
+            public LeafServiceB(IService injectedService = null)
+            {
+                InjectedService = injectedService;
+            }
+
+            public IService InjectedService { get; }
+        }
+
+        private class CompositeService : ICompositeService
+        {
+            public CompositeService(IEnumerable<ICompositeService> aggregatedServices, IService injectedService = null)
+            {
+                AggregatedServices = aggregatedServices;
+                InjectedService = injectedService;
+            }
+
+            public IEnumerable<ICompositeService> AggregatedServices { get; }
+            public IService InjectedService { get; }
+        }
+    }
+}

--- a/test/Scrutor.Tests/OpenGenericAggregationTests.cs
+++ b/test/Scrutor.Tests/OpenGenericAggregationTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Scrutor.Tests
+{
+    public class OpenGenericAggregationTests: TestBase
+    {
+        [Fact]
+        public void CanAggregateOpenGenericBasedOnClass()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<Validator<Entity1>, Entity1ValidatorA>();
+                services.AddTransient<Validator<Entity1>, Entity1ValidatorB>();
+                services.Aggregate(typeof(Validator<>), typeof(CompositeValidator<>));
+            });
+
+            var instance = provider.GetRequiredService<Validator<Entity1>>();
+
+            var aggregator = Assert.IsType<CompositeValidator<Entity1>>(instance);
+            Assert.Collection(aggregator.Validators,
+                validator => Assert.IsType<Entity1ValidatorA>(validator),
+                validator => Assert.IsType<Entity1ValidatorB>(validator));
+        }
+
+        [Fact]
+        public void CanAggregateOpenGenericBasedOnInterface()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorA>();
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorB>();
+                services.Aggregate(typeof(IValidator<>), typeof(CompositeValidator<>));
+            });
+
+            var instance = provider.GetRequiredService<IValidator<Entity1>>();
+
+            var aggregator = Assert.IsType<CompositeValidator<Entity1>>(instance);
+            Assert.Collection(aggregator.Validators,
+                validator => Assert.IsType<Entity1ValidatorA>(validator),
+                validator => Assert.IsType<Entity1ValidatorB>(validator));
+        }
+
+        [Fact]
+        public void CanAggregateOpenGenericOfProperTypeArgument()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorA>();
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorB>();
+                services.AddTransient<IValidator<Entity2>, Entity2Validator>();
+                services.Aggregate(typeof(IValidator<>), typeof(CompositeValidator<>));
+            });
+
+            var instance = provider.GetRequiredService<IValidator<Entity1>>();
+
+            var aggregator = Assert.IsType<CompositeValidator<Entity1>>(instance);
+            Assert.All(aggregator.Validators, Assert.IsNotType<Entity2Validator>);
+        }
+
+        [Fact]
+        public void CanAggregateOpenGenericsWithClosedGenerics()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorA>();
+                services.AddTransient<IValidator<Entity1>, Entity1ValidatorB>();
+                services.AddTransient(typeof(IValidator<>), typeof(Validator<>));
+                services.Aggregate(typeof(IValidator<>), typeof(CompositeValidator<>));
+            });
+
+            var instance = provider.GetRequiredService<IValidator<Entity1>>();
+
+            var aggregator = Assert.IsType<CompositeValidator<Entity1>>(instance);
+            Assert.Collection(aggregator.Validators,
+                validator => Assert.IsType<Entity1ValidatorA>(validator),
+                validator => Assert.IsType<Entity1ValidatorB>(validator),
+                validator => Assert.IsType<Validator<Entity1>>(validator));
+        }
+
+        //[Fact]
+        //public void CanAggregateClosedGenericsOnly()
+        //{
+        //    var provider = ConfigureProvider(services =>
+        //    {
+        //        services.AddTransient(typeof(IValidator<>), typeof(Validator<>));
+        //        services.AddTransient(typeof(IValidator<>), typeof(OtherValidator<>));
+        //        services.Aggregate(typeof(IValidator<>), typeof(CompositeValidator<>));
+        //    });
+
+        //    var instance = provider.GetRequiredService<IValidator<Entity1>>();
+
+        //    var aggregator = Assert.IsType<CompositeValidator<Entity1>>(instance);
+        //    Assert.Collection(aggregator.Validators,
+        //        validator => Assert.IsType<Validator<Entity1>>(validator),
+        //        validator => Assert.IsType<OtherValidator<Entity1>>(validator));
+        //}
+
+        [Fact]
+        public void AggregatingNonRegisteredOpenGenericServiceThrows()
+        {
+            Assert.Throws<MissingTypeRegistrationException>(() => ConfigureProvider(services => services.Aggregate(typeof(IValidator<>), typeof(CompositeValidator<>))));
+        }
+
+        public interface IValidator<T> { }
+
+        private class Validator<T> : IValidator<T> { }
+
+        private class OtherValidator<T> : IValidator<T> { }
+
+        private class Entity1 { }
+
+        private class Entity2 { }
+
+        private class Entity1ValidatorA : Validator<Entity1>
+        {
+        }
+
+        private class Entity1ValidatorB : Validator<Entity1>
+        {
+        }
+
+        private class Entity2Validator : Validator<Entity2>
+        {
+        }
+
+        private class CompositeValidator<T> : Validator<T>
+        {
+            public CompositeValidator(IEnumerable<IValidator<T>> validators)
+            {
+                Validators = validators;
+            }
+
+            public IEnumerable<IValidator<T>> Validators { get; }
+        }
+    }
+}


### PR DESCRIPTION
This is a new feature suggestion. It adds a new `Aggregate` extension method on `IServiceCollection`. This method is similar to the `Decorate` method, except that instead of decorating all matching service descriptors with a decorator type, it aggregates them inside an aggregator type. This can be useful when implementing the composite design pattern.

Example:

```csharp
interface IValidator {}

class ValidatorA : IValidator {}

class ValidatorB: IValidator {}

class CompositeValidator: IValidator
{
    private readonly IEnumerable<IValidator> _validators;

    public CompositeValidator(IEnumerable<IValidator> validators)
    {
        this._validators = validators;
    }
}

void RegisterServices(IServiceCollection services)
{
    services.AddTransient<IValidator, ValidatorA>();
    services.AddTransient<IValidator, ValidatorB>();
    services.Aggregate<IValidator, CompositeValidator>();
}

void Run(IServiceProvider provider)
{
    var validator = provider.GetRequiredService<IValidator>();
    // validator is a CompositeValidator instance encapsulating a ValidatorA instance and a ValidatorB instance
}
```