### PR TITLE
Add extension methods for adding services with custom dependencies

### DIFF
--- a/src/Scrutor/CircularDependencyException.cs
+++ b/src/Scrutor/CircularDependencyException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Scrutor
+{
+    public class CircularDependencyException : InvalidOperationException
+    {
+        public CircularDependencyException(Type creatingServiceType, Type requestedServiceType)
+            : base(
+                $"A circular dependency was detected for the service of type '{creatingServiceType.Name}'." +
+                $"\r\n" +
+                $"{creatingServiceType.Name} -> {requestedServiceType}"
+            )
+        {
+        }
+    }
+}

--- a/src/Scrutor/IInjectionContext.cs
+++ b/src/Scrutor/IInjectionContext.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Scrutor
+{
+    public interface IInjectionContext
+    {
+        Type CreatingServiceType { get; }
+    }
+}

--- a/src/Scrutor/InjectionContext.cs
+++ b/src/Scrutor/InjectionContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Scrutor
+{
+    internal class InjectionContext : IInjectionContext
+    {
+        public Type CreatingServiceType { get; }
+
+        public InjectionContext(Type creatingServiceType)
+        {
+            CreatingServiceType = creatingServiceType;
+        }
+    }
+}

--- a/src/Scrutor/InjectionContextAwareServiceProvider.cs
+++ b/src/Scrutor/InjectionContextAwareServiceProvider.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scrutor
+{
+    internal struct InjectionContextAwareServiceProvider : IServiceProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IInjectionContext _injectionContext;
+        private readonly Func<IServiceProvider, IInjectionContext, object[]> _dependenciesFactory;
+
+        public InjectionContextAwareServiceProvider(
+            IServiceProvider serviceProvider,
+            IInjectionContext injectionContext,
+            Func<IServiceProvider, IInjectionContext, object[]> dependenciesFactory
+        )
+        {
+            _serviceProvider = new SubServiceProvider(serviceProvider, injectionContext);
+            _injectionContext = injectionContext;
+            _dependenciesFactory = dependenciesFactory;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return ActivatorUtilities.CreateInstance(
+                _serviceProvider,
+                serviceType,
+                _dependenciesFactory(_serviceProvider, _injectionContext)
+            );
+        }
+
+        private struct SubServiceProvider : IServiceProvider
+        {
+            private readonly IServiceProvider _serviceProvider;
+            private readonly IInjectionContext _injectionContext;
+
+            public SubServiceProvider(
+                IServiceProvider serviceProvider,
+                IInjectionContext injectionContext
+            )
+            {
+                _serviceProvider = serviceProvider;
+                _injectionContext = injectionContext;
+            }
+
+            public object GetService(Type serviceType)
+            {
+                if (serviceType == _injectionContext.CreatingServiceType)
+                    throw new CircularDependencyException(_injectionContext.CreatingServiceType, serviceType);
+
+                return _serviceProvider.GetService(serviceType);
+            }
+        }
+    }
+}

--- a/src/Scrutor/ServiceCollectionExtensions.Dependencies.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Dependencies.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Scrutor;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Overrides the dependencies for every service
+        /// registered in the <paramref name="addServices"/> <see cref="Action"/>.
+        /// </summary>
+        /// <param name="services">The services to add to.</param>
+        /// <param name="addServices">The action in which you configure the services.</param>
+        /// <param name="dependenciesTypes">The types of the dependencies.</param>
+        /// <exception cref="ArgumentNullException">
+        /// If either the <paramref name="services"/>, <paramref name="addServices"/>
+        /// or <paramref name="dependenciesTypes"/> arguments are <c>null</c>.
+        /// </exception>
+        public static IServiceCollection AddWithDependencies(
+            this IServiceCollection services,
+            Action addServices,
+            params Type[] dependenciesTypes
+        )
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(addServices, nameof(addServices));
+            Preconditions.NotNull(dependenciesTypes, nameof(dependenciesTypes));
+
+            services.AddWithDependencies(
+                addServices,
+                (serviceProvider, injectionContext) => dependenciesTypes.Select(serviceProvider.GetRequiredService).ToArray()
+            );
+
+            return services;
+        }
+
+        /// <summary>
+        /// Overrides the dependencies for every service
+        /// registered in the <paramref name="addServices"/> <see cref="Action"/>.
+        /// </summary>
+        /// <param name="services">The services to add to.</param>
+        /// <param name="addServices">The action in which you configure the services.</param>
+        /// <param name="dependenciesFactory">A factory that returns instances of the dependencies.</param>
+        /// <exception cref="ArgumentNullException">
+        /// If either the <paramref name="services"/>, <paramref name="addServices"/>
+        /// or <paramref name="dependenciesFactory"/> arguments are <c>null</c>.
+        /// </exception>
+        public static IServiceCollection AddWithDependencies(
+            this IServiceCollection services,
+            Action addServices,
+            Func<IServiceProvider, object[]> dependenciesFactory
+        )
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(addServices, nameof(addServices));
+            Preconditions.NotNull(dependenciesFactory, nameof(dependenciesFactory));
+
+            services.AddWithDependencies(
+                addServices,
+                (serviceProvider, injectionContext) => dependenciesFactory(serviceProvider)
+            );
+
+            return services;
+        }
+
+        /// <summary>
+        /// Overrides the dependencies for every service
+        /// registered in the <paramref name="addServices"/> <see cref="Action"/>.
+        /// </summary>
+        /// <param name="services">The services to add to.</param>
+        /// <param name="addServices">The action in which you configure the services.</param>
+        /// <param name="dependenciesFactory">
+        /// A factory with an <see cref="IInjectionContext"/>
+        /// (Which provides the type of the event the dependencies are being injected)
+        /// that returns instances of the dependencies.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If either the <paramref name="services"/>, <paramref name="addServices"/>
+        /// or <paramref name="dependenciesFactory"/> arguments are <c>null</c>.
+        /// </exception>
+        public static IServiceCollection AddWithDependencies(
+            this IServiceCollection services,
+            Action addServices,
+            Func<IServiceProvider, IInjectionContext, object[]> dependenciesFactory
+        )
+        {
+            Preconditions.NotNull(services, nameof(services));
+            Preconditions.NotNull(addServices, nameof(addServices));
+            Preconditions.NotNull(dependenciesFactory, nameof(dependenciesFactory));
+
+            var addedServices = GetAddedServices(services, addServices);
+
+            foreach (var addedService in addedServices)
+                services.AddWithDependencies(addedService, dependenciesFactory);
+
+            return services;
+        }
+
+        private static void AddWithDependencies(
+            this IServiceCollection services,
+            ServiceDescriptor serviceDescriptor,
+            Func<IServiceProvider, IInjectionContext, object[]> dependenciesFactory
+        )
+        {
+            var injectionContext = new InjectionContext(serviceDescriptor.ServiceType);
+
+            if (serviceDescriptor.ImplementationType != null)
+            {
+                services.ReplaceServiceFactory(serviceDescriptor, serviceProvider =>
+                {
+                    var factoryServiceProvider = new InjectionContextAwareServiceProvider(
+                        serviceProvider,
+                        injectionContext,
+                        dependenciesFactory
+                    );
+
+                    return factoryServiceProvider.GetService(serviceDescriptor.ImplementationType);
+                });
+            }
+            else if (serviceDescriptor.ImplementationFactory != null)
+            {
+                services.ReplaceServiceFactory(serviceDescriptor, serviceProvider =>
+                {
+                    var factoryServiceProvider = new InjectionContextAwareServiceProvider(
+                        serviceProvider,
+                        injectionContext,
+                        dependenciesFactory
+                    );
+
+                    var service = serviceDescriptor.ImplementationFactory(factoryServiceProvider);
+
+                    return service;
+                });
+            }
+        }
+
+        private static IEnumerable<ServiceDescriptor> GetAddedServices(IServiceCollection services, Action addServices)
+        {
+            var originalServices = services.ToArray();
+            addServices();
+            var addedServices = services.Where(x => originalServices.All(y => y != x)).ToArray();
+
+            return addedServices;
+        }
+
+        private static void ReplaceServiceFactory(
+            this IServiceCollection services,
+            ServiceDescriptor serviceDescriptor,
+            Func<IServiceProvider, object> factory
+        )
+        {
+            services.Replace(new ServiceDescriptor(serviceDescriptor.ServiceType, factory, serviceDescriptor.Lifetime));
+        }
+    }
+}

--- a/test/Scrutor.Tests/DependenciesTests.cs
+++ b/test/Scrutor.Tests/DependenciesTests.cs
@@ -1,0 +1,277 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Scrutor.Tests
+{
+
+    public class DependenciesTests : TestBase
+    {
+        [Fact]
+        public void CanInjectDesiredDependencyUsingDependenciesTypes()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<int>, Dependency1<int>>();
+                services.AddTransient<IDependency1<string>, Dependency1<string>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                }, typeof(IDependency1<string>));
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<string>));
+        }
+
+        [Fact]
+        public void CanInjectDesiredDependencyUsingDependenciesFactory()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<int>, Dependency1<int>>();
+                services.AddTransient<IDependency1<string>, Dependency1<string>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                }, provider => new object[] { provider.GetRequiredService<IDependency1<string>>() });
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<string>));
+        }
+
+        [Fact]
+        public void CanInjectDesiredDependencyUsingDependenciesFactoryWithInjectionContext()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<Dependant2>, Dependency1<Dependant2>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                },
+                (provider, injectionContext) => new object[]
+                {
+                    provider.GetRequiredService(
+                        typeof(IDependency1<>).MakeGenericType(injectionContext.CreatingServiceType)
+                    )
+                });
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<Dependant2>));
+        }
+
+        [Fact]
+        public void CanInjectMultipleDependenciesDependencyUsingDependenciesTypes()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<int>, Dependency1<int>>();
+                services.AddTransient<IDependency1<string>, Dependency1<string>>();
+                services.AddTransient<IDependency2<int>, Dependency2<int>>();
+                services.AddTransient<IDependency2<string>, Dependency2<string>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                }, typeof(IDependency1<string>), typeof(IDependency2<string>));
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<string>));
+            Assert.Same(dependant.Dependency2.GetType(), typeof(Dependency2<string>));
+        }
+
+        [Fact]
+        public void CanInjectMultipleDependenciesDependencyUsingDependenciesFactory()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<int>, Dependency1<int>>();
+                services.AddTransient<IDependency1<string>, Dependency1<string>>();
+                services.AddTransient<IDependency2<int>, Dependency2<int>>();
+                services.AddTransient<IDependency2<string>, Dependency2<string>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                },
+                provider => new object[]
+                {
+                    provider.GetRequiredService<IDependency1<string>>(),
+                    provider.GetRequiredService<IDependency2<string>>()
+                });
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<string>));
+            Assert.Same(dependant.Dependency2.GetType(), typeof(Dependency2<string>));
+        }
+
+        [Fact]
+        public void CanInjectMultipleDependenciesUsingDependenciesFactoryWithInjectionContext()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependency1<Dependant2>, Dependency1<Dependant2>>();
+                services.AddTransient<IDependency2<Dependant2>, Dependency2<Dependant2>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant2>();
+                },
+                (provider, injectionContext) => new object[]
+                {
+                    provider.GetRequiredService(
+                        typeof(IDependency1<>).MakeGenericType(injectionContext.CreatingServiceType)
+                    ),
+                    provider.GetRequiredService(
+                        typeof(IDependency2<>).MakeGenericType(injectionContext.CreatingServiceType)
+                    )
+                });
+            });
+
+            var dependant = serviceProvider.GetRequiredService<Dependant2>();
+
+            Assert.Same(dependant.Dependency1.GetType(), typeof(Dependency1<Dependant2>));
+            Assert.Same(dependant.Dependency2.GetType(), typeof(Dependency2<Dependant2>));
+        }
+
+        [Fact]
+        public void CanInjectDesiredDependenciesWithMultipleLevels()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddTransient<IDependant2, Dependant2>();
+                services.AddTransient<Dependency1<int>>();
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<AlternativeDependant2>();
+                }, typeof(Dependency1<int>));
+
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant1>();
+                },
+                provider => new object[]
+                {
+                    provider.GetRequiredService<AlternativeDependant2>()
+                });
+            });
+
+            var dependant1 = serviceProvider.GetRequiredService<Dependant1>();
+
+            Assert.Same(dependant1.Dependant2.GetType(), typeof(AlternativeDependant2));
+            Assert.Same(dependant1.Dependant2.Dependency1.GetType(), typeof(Dependency1<int>));
+        }
+
+        [Fact]
+        public void CanDetectCircularDependencyWithNestedCalls()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant1>();
+
+                    services.AddWithDependencies(() =>
+                    {
+                        services.AddTransient<AlternativeDependant2>();
+                    });
+                },
+                provider => new object[]
+                {
+                    provider.GetRequiredService<AlternativeDependant2>()
+                });
+            });
+
+            Assert.Throws<CircularDependencyException>(() =>
+            {
+                serviceProvider.GetRequiredService<Dependant1>();
+            });
+        }
+
+        [Fact]
+        public void CanDetectCircularDependency()
+        {
+            var serviceProvider = ConfigureProvider(services =>
+            {
+                services.AddWithDependencies(() =>
+                {
+                    services.AddTransient<Dependant1>();
+
+                    services.AddTransient<AlternativeDependant2>();
+                },
+                provider => new object[]
+                {
+                    provider.GetRequiredService<AlternativeDependant2>()
+                });
+            });
+
+            Assert.Throws<CircularDependencyException>(() =>
+            {
+                serviceProvider.GetRequiredService<Dependant1>();
+            });
+        }
+
+        private interface IDependency1 { }
+
+        private interface IDependency1<T> : IDependency1 { }
+
+        private class Dependency1<T> : IDependency1<T> { }
+
+        private interface IDependency2 { }
+
+        private interface IDependency2<T> : IDependency2 { }
+
+        private class Dependency2<T> : IDependency2<T> { }
+
+        private interface IDependant2
+        {
+            IDependency1 Dependency1 { get; }
+        }
+
+        private class Dependant2 : IDependant2
+        {
+            public IDependency1 Dependency1 { get; }
+            public IDependency2 Dependency2 { get; }
+
+            public Dependant2(IDependency1 dependency1, IDependency2 dependency2 = null)
+            {
+                Dependency1 = dependency1;
+                Dependency2 = dependency2;
+            }
+        }
+
+        private class AlternativeDependant2 : IDependant2
+        {
+            public IDependency1 Dependency1 { get; }
+
+            public AlternativeDependant2(IDependency1 dependency1)
+            {
+                Dependency1 = dependency1;
+            }
+        }
+
+        private class Dependant1
+        {
+            public IDependant2 Dependant2 { get; }
+
+            public Dependant1(IDependant2 dependant2)
+            {
+                Dependant2 = dependant2;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds extension methods for defining cutom dependencies on specific services.

I came up with this idea because a lot of people didn't like the approach MS have taken with the generic `ILogger<T>` and the named `IOptions<TOptions>` (If you have multiple `IOptions<TOptions>` of the same type you have to retrive the correct instance by name inside of the costructor of the service where they are being injected)

### Common usages:
- Inject the desired service when multiple implementations are registered:

```csharp
var services = new ServiceCollection();

services.AddSingleton<SomeService1>();
services.AddSingleton<SomeService2>();

services.AddWithDependencies(() =>
{
    services.AddSingleton<MainService>();
}, typeof(SomeService2));

public interface ISomeService { }

public class SomeService1 : ISomeService { }
public class SomeService2 : ISomeService { }

public class MainService 
{
    public MainService(ISomeService someService)
    {
        // someService.GetType() == typeof(SomeService2)
    }
}
```

- Avoid injecting the generic `ILogger<T>`:

```csharp
var services = new ServiceCollection();

services.AddLogging();

services.AddWithDependencies(() =>
{
    services.AddSingleton<SomeService>();
    services.AddSingleton<SomeOtherService>();
},
(serviceProvider, injectionContext) => new [] {
     serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(injectionContext.CreatingServiceType)
});

public class SomeService
{
    public SomeService(ILogger logger) 
    { 
        // logger.GetType() == typeof(Logger<SomeService>)
    }
}

public class SomeOtherService
{
    public SomeOtherService(ILogger logger) 
    { 
        // logger.GetType() == typeof(Logger<SomeOtherService>)
    }
}
```