### PR TITLE
Add `ScanStatic` extension method using C# Source Generators

### DIFF
--- a/Scrutor.sln
+++ b/Scrutor.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scrutor", "src\Scrutor\Scru
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scrutor.Tests", "test\Scrutor.Tests\Scrutor.Tests.csproj", "{B065DC10-3AD1-462B-A90E-9BE86403243E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scrutor.Analyzers", "src\Scrutor.Analyzers\Scrutor.Analyzers.csproj", "{413885A5-EB8B-4097-BC7C-B4EF5159F106}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{B065DC10-3AD1-462B-A90E-9BE86403243E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B065DC10-3AD1-462B-A90E-9BE86403243E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B065DC10-3AD1-462B-A90E-9BE86403243E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{413885A5-EB8B-4097-BC7C-B4EF5159F106}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{413885A5-EB8B-4097-BC7C-B4EF5159F106}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{413885A5-EB8B-4097-BC7C-B4EF5159F106}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{413885A5-EB8B-4097-BC7C-B4EF5159F106}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -38,5 +44,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1D63DA77-E425-4FEA-BC82-94A8F6C3024E} = {3F8D19AB-70F9-4640-BEDE-BBDA2AA4EE9D}
 		{B065DC10-3AD1-462B-A90E-9BE86403243E} = {34EEB067-2738-4DD0-8596-D67A9461833A}
+		{413885A5-EB8B-4097-BC7C-B4EF5159F106} = {3F8D19AB-70F9-4640-BEDE-BBDA2AA4EE9D}
 	EndGlobalSection
 EndGlobal

--- a/src/Scrutor.Analyzers/DataHelpers.cs
+++ b/src/Scrutor.Analyzers/DataHelpers.cs
@@ -230,7 +230,7 @@ namespace Scrutor.Analyzers
                         yield return new CompiledServiceTypeDescriptor(nts);
                         yield break;
                     default:
-                        context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                         yield break;
                 }
             }
@@ -304,12 +304,13 @@ namespace Scrutor.Analyzers
                                 continue;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
 
                     context.ReportDiagnostic(Diagnostic.Create(Diagnostics.MustBeTypeOf, argument.Expression.GetLocation()));
+                    yield return new CompiledAbortTypeFilterDescriptor(context.Compilation.ObjectType);
                     yield break;
                 }
 
@@ -331,7 +332,7 @@ namespace Scrutor.Analyzers
                                 yield break;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
@@ -352,7 +353,7 @@ namespace Scrutor.Analyzers
                                 yield break;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
@@ -373,7 +374,7 @@ namespace Scrutor.Analyzers
                                 yield break;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
@@ -420,12 +421,13 @@ namespace Scrutor.Analyzers
                                 yield return new CompiledAssignableToTypeFilterDescriptor(nts);
                                 yield break;
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
 
                     context.ReportDiagnostic(Diagnostic.Create(Diagnostics.MustBeTypeOf, simpleNameSyntax.Identifier.GetLocation()));
+                    yield return new CompiledAbortTypeFilterDescriptor(context.Compilation.ObjectType);
                     yield break;
                 }
 
@@ -442,7 +444,7 @@ namespace Scrutor.Analyzers
                                 yield break;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }
@@ -463,7 +465,7 @@ namespace Scrutor.Analyzers
                                 yield break;
 
                             default:
-                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.TypeNotResolved, name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnhandledSymbol, name.GetLocation()));
                                 yield break;
                         }
                     }

--- a/src/Scrutor.Analyzers/DataHelpers.cs
+++ b/src/Scrutor.Analyzers/DataHelpers.cs
@@ -47,6 +47,8 @@ namespace Scrutor.Analyzers
                 expression = body;
             }
 
+            rootExpression = expression;
+
             if (expression.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax
              && memberAccessExpressionSyntax.IsKind(SyntaxKind.SimpleMemberAccessExpression))
             {

--- a/src/Scrutor.Analyzers/DataHelpers.cs
+++ b/src/Scrutor.Analyzers/DataHelpers.cs
@@ -211,7 +211,7 @@ namespace Scrutor.Analyzers
 
             if (name is GenericNameSyntax genericNameSyntax && genericNameSyntax.TypeArgumentList.Arguments.Count == 1)
             {
-                var typeSyntax = ExtractSyntaxFromMethod(expression, name);
+                var typeSyntax = Helpers.ExtractSyntaxFromMethod(expression, name);
                 if (typeSyntax == null)
                 {
                     yield break;
@@ -241,7 +241,7 @@ namespace Scrutor.Analyzers
             if (name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblies))
                 return new AllAssemblyDescriptor();
 
-            var typeSyntax = ExtractSyntaxFromMethod(expression, name);
+            var typeSyntax = Helpers.ExtractSyntaxFromMethod(expression, name);
             if (typeSyntax == null)
                 return null;
 
@@ -314,7 +314,7 @@ namespace Scrutor.Analyzers
             {
                 if (genericNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.AssignableTo))
                 {
-                    var type = ExtractSyntaxFromMethod(expression, name);
+                    var type = Helpers.ExtractSyntaxFromMethod(expression, name);
                     if (type != null)
                     {
                         var typeInfo = semanticModel.GetTypeInfo(type).Type;
@@ -362,10 +362,10 @@ namespace Scrutor.Analyzers
             {
                 if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.AssignableTo))
                 {
-                    var type = ExtractSyntaxFromMethod(expression, name);
+                    var type = Helpers.ExtractSyntaxFromMethod(expression, name);
                     if (type != null)
                     {
-                        var typeInfo = type == null ? null : semanticModel.GetTypeInfo(type).Type;
+                        var typeInfo = semanticModel.GetTypeInfo(type).Type;
                         switch (typeInfo)
                         {
                             case INamedTypeSymbol nts:
@@ -423,30 +423,6 @@ namespace Scrutor.Analyzers
                     yield break;
                 }
             }
-        }
-
-        static TypeSyntax? ExtractSyntaxFromMethod(
-            InvocationExpressionSyntax expression,
-            NameSyntax name
-        )
-        {
-            if (name is GenericNameSyntax genericNameSyntax)
-            {
-                if (genericNameSyntax.TypeArgumentList.Arguments.Count == 1)
-                {
-                    return genericNameSyntax.TypeArgumentList.Arguments[0];
-                }
-            }
-
-            if (name is SimpleNameSyntax)
-            {
-                if (expression.ArgumentList.Arguments.Count == 1 && expression.ArgumentList.Arguments[0].Expression is TypeOfExpressionSyntax typeOfExpression)
-                {
-                    return typeOfExpression.Type;
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/src/Scrutor.Analyzers/DataHelpers.cs
+++ b/src/Scrutor.Analyzers/DataHelpers.cs
@@ -250,10 +250,10 @@ namespace Scrutor.Analyzers
                 return null;
             return typeInfo switch
             {
-                INamedTypeSymbol nts when name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblyDependenciesOf) => new CompiledAssemblyDependenciesDescriptor(
-                    nts
-                ),
-                INamedTypeSymbol nts when name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblyOf) => new CompiledAssemblyDescriptor(nts),
+                INamedTypeSymbol nts when name.ToFullString().StartsWith(nameof(ICompiledAssemblySelector.FromAssemblyDependenciesOf)) =>
+                    new CompiledAssemblyDependenciesDescriptor(nts),
+                INamedTypeSymbol nts when name.ToFullString().StartsWith(nameof(ICompiledAssemblySelector.FromAssemblyOf)) =>
+                    new CompiledAssemblyDescriptor(nts),
                 _ => null
             };
         }
@@ -382,17 +382,20 @@ namespace Scrutor.Analyzers
                 }
 
                 NamespaceFilter? filter = null;
-                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaces) || simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaceOf))
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaces) ||
+                    simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaceOf))
                 {
                     filter = NamespaceFilter.Exact;
                 }
 
-                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaces) || simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaceOf))
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaces) ||
+                    simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaceOf))
                 {
                     filter = NamespaceFilter.In;
                 }
 
-                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaces) || simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaceOf))
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaces) ||
+                    simpleNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaceOf))
                 {
                     filter = NamespaceFilter.NotIn;
                 }

--- a/src/Scrutor.Analyzers/DataHelpers.cs
+++ b/src/Scrutor.Analyzers/DataHelpers.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Scrutor.Analyzers.Internals;
+using Scrutor.Static;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Scrutor.Analyzers
+{
+    static class DataHelpers
+    {
+        public static void HandleInvocationExpressionSyntax(
+            CSharpCompilation compilation,
+            SemanticModel semanticModel,
+            ExpressionSyntax rootExpression,
+            List<IAssemblyDescriptor> assemblies,
+            List<ITypeFilterDescriptor> typeFilters,
+            List<IServiceTypeDescriptor> serviceTypes,
+            ref ClassFilter classFilter,
+            ref MemberAccessExpressionSyntax lifetimeExpressionSyntax
+        )
+        {
+            if (!(rootExpression is InvocationExpressionSyntax expression))
+            {
+                if (!(rootExpression is SimpleLambdaExpressionSyntax simpleLambdaExpressionSyntax))
+                {
+                    // report diagnostic
+                    return;
+                }
+
+                if (simpleLambdaExpressionSyntax.ExpressionBody == null)
+                {
+                    // we don't support blocks
+                    // report diagnostic
+                    return;
+                }
+
+                if (!(simpleLambdaExpressionSyntax.ExpressionBody is InvocationExpressionSyntax body))
+                {
+                    // we only support invocation expressions
+                    // report diagnostic
+                    return;
+                }
+
+                expression = body;
+            }
+
+            if (expression.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax
+             && memberAccessExpressionSyntax.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            {
+                if (memberAccessExpressionSyntax.Expression is InvocationExpressionSyntax childExpression)
+                {
+                    HandleInvocationExpressionSyntax(
+                        compilation,
+                        semanticModel,
+                        childExpression,
+                        assemblies,
+                        typeFilters,
+                        serviceTypes,
+                        ref classFilter,
+                        ref lifetimeExpressionSyntax
+                    );
+                }
+
+                var type = semanticModel.GetTypeInfo(memberAccessExpressionSyntax.Expression);
+                if (type.Type != null)
+                {
+                    var typeName = type.Type.ToDisplayString();
+                    if (typeName == "Scrutor.Static.ICompiledAssemblySelector")
+                    {
+                        var selector = HandleCompiledAssemblySelector(
+                            semanticModel,
+                            expression,
+                            memberAccessExpressionSyntax.Name
+                        );
+                        if (selector != null)
+                        {
+                            assemblies.Add(selector);
+                        }
+                    }
+
+                    if (typeName == "Scrutor.Static.ICompiledImplementationTypeSelector")
+                    {
+                        var selector = HandleCompiledAssemblySelector(
+                            semanticModel,
+                            expression,
+                            memberAccessExpressionSyntax.Name
+                        );
+                        if (selector != null)
+                        {
+                            assemblies.Add(selector);
+                        }
+                        else
+                        {
+                            classFilter = HandleCompiledImplementationTypeSelector(expression, memberAccessExpressionSyntax.Name);
+                        }
+                    }
+
+                    if (typeName == "Scrutor.Static.ICompiledImplementationTypeFilter")
+                    {
+                        typeFilters.AddRange(HandleCompiledImplementationTypeFilter(semanticModel, expression, memberAccessExpressionSyntax.Name));
+                    }
+
+                    if (typeName == "Scrutor.Static.ICompiledServiceTypeSelector")
+                    {
+                        serviceTypes.AddRange(HandleCompiledServiceTypeSelector(semanticModel, expression, memberAccessExpressionSyntax.Name));
+                    }
+
+                    if (typeName == "Scrutor.Static.ICompiledLifetimeSelector")
+                    {
+                        serviceTypes.AddRange(HandleCompiledServiceTypeSelector(semanticModel, expression, memberAccessExpressionSyntax.Name));
+                        lifetimeExpressionSyntax = HandleCompiledLifetimeSelector(semanticModel, expression, memberAccessExpressionSyntax.Name) ?? lifetimeExpressionSyntax;
+                    }
+                }
+
+                foreach (var argument in expression.ArgumentList.Arguments)
+                {
+                    HandleInvocationExpressionSyntax(
+                        compilation,
+                        semanticModel,
+                        argument.Expression,
+                        assemblies,
+                        typeFilters,
+                        serviceTypes,
+                        ref classFilter,
+                        ref lifetimeExpressionSyntax
+                    );
+                }
+            }
+        }
+
+        static MemberAccessExpressionSyntax? HandleCompiledLifetimeSelector(
+            SemanticModel semanticModel,
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name.ToFullString() == nameof(ICompiledLifetimeSelector.WithSingletonLifetime))
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ServiceLifetime"),
+                    SyntaxFactory.IdentifierName("Singleton")
+                );
+            }
+
+            if (name.ToFullString() == nameof(ICompiledLifetimeSelector.WithScopedLifetime))
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ServiceLifetime"),
+                    SyntaxFactory.IdentifierName("Scoped")
+                );
+            }
+
+            if (name.ToFullString() == nameof(ICompiledLifetimeSelector.WithTransientLifetime))
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ServiceLifetime"),
+                    SyntaxFactory.IdentifierName("Transient")
+                );
+            }
+
+            if (name.ToFullString() == nameof(ICompiledLifetimeSelector.WithLifetime) && expression.ArgumentList.Arguments.Count == 1)
+            {
+                if (expression.ArgumentList.Arguments[0].Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
+                    return memberAccessExpressionSyntax;
+                throw new NotSupportedException();
+            }
+
+            return null;
+        }
+
+        static IEnumerable<IServiceTypeDescriptor> HandleCompiledServiceTypeSelector(
+            SemanticModel semanticModel,
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name.ToFullString() == nameof(ICompiledServiceTypeSelector.AsSelf))
+            {
+                yield return new SelfServiceTypeDescriptor();
+                yield break;
+            }
+
+            if (name.ToFullString() == nameof(ICompiledServiceTypeSelector.AsImplementedInterfaces))
+            {
+                yield return new ImplementedInterfacesServiceTypeDescriptor();
+                yield break;
+            }
+
+            if (name.ToFullString() == nameof(ICompiledServiceTypeSelector.AsMatchingInterface))
+            {
+                yield return new MatchingInterfaceServiceTypeDescriptor();
+                yield break;
+            }
+
+            if (name.ToFullString() == nameof(ICompiledServiceTypeSelector.AsSelfWithInterfaces))
+            {
+                yield return new SelfServiceTypeDescriptor();
+                yield return new ImplementedInterfacesServiceTypeDescriptor();
+                yield break;
+            }
+
+            if (name is GenericNameSyntax genericNameSyntax && genericNameSyntax.TypeArgumentList.Arguments.Count == 1)
+            {
+                var typeSyntax = ExtractSyntaxFromMethod(expression, name);
+                if (typeSyntax == null)
+                {
+                    yield break;
+                }
+
+                var typeInfo = semanticModel.GetTypeInfo(typeSyntax).Type;
+                switch (typeInfo)
+                {
+                    case null:
+                        yield break;
+                    case INamedTypeSymbol nts:
+                        yield return new CompiledServiceTypeDescriptor(nts);
+                        yield break;
+                }
+            }
+        }
+
+        static IAssemblyDescriptor? HandleCompiledAssemblySelector(
+            SemanticModel semanticModel,
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssembly))
+                return new AssemblyDescriptor(semanticModel.Compilation.Assembly);
+            if (name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblies))
+                return new AllAssemblyDescriptor();
+
+            var typeSyntax = ExtractSyntaxFromMethod(expression, name);
+            if (typeSyntax == null)
+                return null;
+
+            var typeInfo = semanticModel.GetTypeInfo(typeSyntax).Type;
+            if (typeInfo == null)
+                return null;
+            return typeInfo switch
+            {
+                INamedTypeSymbol nts when name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblyDependenciesOf) => new CompiledAssemblyDependenciesDescriptor(
+                    nts
+                ),
+                INamedTypeSymbol nts when name.ToFullString() == nameof(ICompiledAssemblySelector.FromAssemblyOf) => new CompiledAssemblyDescriptor(nts),
+                _ => null
+            };
+        }
+
+        static ClassFilter HandleCompiledImplementationTypeSelector(
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name.ToFullString() == nameof(ICompiledImplementationTypeSelector.AddClasses) && expression.ArgumentList.Arguments.Count is >= 0 and <= 2)
+            {
+                foreach (var argument in expression.ArgumentList.Arguments)
+                {
+                    if (argument.Expression is LiteralExpressionSyntax literalExpressionSyntax && literalExpressionSyntax.Token.IsKind(SyntaxKind.TrueKeyword))
+                    {
+                        return ClassFilter.PublicOnly;
+                    }
+                }
+            }
+
+            return ClassFilter.All;
+        }
+
+        static IEnumerable<ITypeFilterDescriptor> HandleCompiledImplementationTypeFilter(
+            SemanticModel semanticModel,
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name.ToFullString() == nameof(ICompiledImplementationTypeFilter.AssignableToAny))
+            {
+                // diagnostic if not using typeof
+                foreach (var argument in expression.ArgumentList.Arguments!)
+                {
+                    if (argument.Expression is TypeOfExpressionSyntax typeOfExpressionSyntax)
+                    {
+                        var typeInfo = semanticModel.GetTypeInfo(typeOfExpressionSyntax.Type).Type;
+                        switch (typeInfo)
+                        {
+                            case null:
+                                yield break;
+                            case INamedTypeSymbol nts:
+                                yield return new CompiledAssignableToAnyTypeFilterDescriptor(nts);
+                                continue;
+                        }
+                    }
+
+                    // todo diagnostic
+                }
+
+                yield break;
+            }
+
+            if (name is GenericNameSyntax genericNameSyntax && genericNameSyntax.TypeArgumentList!.Arguments.Count == 1)
+            {
+                if (genericNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.AssignableTo))
+                {
+                    var type = ExtractSyntaxFromMethod(expression, name);
+                    if (type != null)
+                    {
+                        var typeInfo = semanticModel.GetTypeInfo(type).Type;
+                        switch (typeInfo)
+                        {
+                            case null:
+                                yield break;
+                            case INamedTypeSymbol nts:
+                                yield return new CompiledAssignableToTypeFilterDescriptor(nts);
+                                yield break;
+                        }
+                    }
+
+                    // todo diagnostic
+                    yield break;
+                }
+
+                NamespaceFilter? filter = null;
+                if (genericNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaces))
+                {
+                    filter = NamespaceFilter.Exact;
+                }
+
+                if (genericNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaceOf))
+                {
+                    filter = NamespaceFilter.In;
+                }
+
+                if (genericNameSyntax.Identifier.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaceOf))
+                {
+                    filter = NamespaceFilter.NotIn;
+                }
+
+                if (filter.HasValue)
+                {
+                    var symbol = semanticModel.GetDeclaredSymbol(genericNameSyntax.TypeArgumentList.Arguments![0]);
+                    yield return new NamespaceFilterDescriptor(filter.Value, symbol.ContainingNamespace.ToDisplayString());
+                }
+
+                // todo diagnostic
+                yield break;
+            }
+
+            if (name is SimpleNameSyntax simpleNameSyntax)
+            {
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.AssignableTo))
+                {
+                    var type = ExtractSyntaxFromMethod(expression, name);
+                    if (type != null)
+                    {
+                        var typeInfo = semanticModel.GetTypeInfo(type).Type;
+                        switch (typeInfo)
+                        {
+                            case null:
+                                yield break;
+                            case INamedTypeSymbol nts:
+                                yield return new CompiledAssignableToTypeFilterDescriptor(nts);
+                                yield break;
+                        }
+                    }
+
+                    // todo diagnostic
+                    yield break;
+                }
+
+                NamespaceFilter? filter = null;
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InExactNamespaces))
+                {
+                    filter = NamespaceFilter.Exact;
+                }
+
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.InNamespaces))
+                {
+                    filter = NamespaceFilter.In;
+                }
+
+                if (simpleNameSyntax.ToFullString() == nameof(ICompiledImplementationTypeFilter.NotInNamespaces))
+                {
+                    filter = NamespaceFilter.NotIn;
+                }
+
+                if (filter.HasValue)
+                {
+                    foreach (var argument in expression.ArgumentList.Arguments!)
+                    {
+                        if (argument.Expression is LiteralExpressionSyntax literalExpressionSyntax
+                         && literalExpressionSyntax.Token.IsKind(SyntaxKind.StringLiteralExpression))
+                        {
+                            yield return new NamespaceFilterDescriptor(filter.Value, literalExpressionSyntax.Token.ValueText);
+                        }
+                        else
+                        {
+                            // todo diagnostic
+                        }
+                    }
+
+                    yield break;
+                }
+            }
+        }
+
+        static TypeSyntax? ExtractSyntaxFromMethod(
+            InvocationExpressionSyntax expression,
+            NameSyntax name
+        )
+        {
+            if (name is GenericNameSyntax genericNameSyntax)
+            {
+                if (genericNameSyntax.TypeArgumentList.Arguments.Count == 1)
+                {
+                    return genericNameSyntax.TypeArgumentList.Arguments[0];
+                }
+            }
+
+            if (name is SimpleNameSyntax)
+            {
+                if (expression.ArgumentList.Arguments.Count == 1 && expression.ArgumentList.Arguments[0].Expression is TypeOfExpressionSyntax typeOfExpression)
+                {
+                    return typeOfExpression.Type;
+                }
+            }
+
+            // we only support typeof or closed generic arguments
+            // report diagnostic
+
+            return null;
+        }
+    }
+}

--- a/src/Scrutor.Analyzers/Diagnostics.cs
+++ b/src/Scrutor.Analyzers/Diagnostics.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
 
 namespace Scrutor.Analyzers
 {
-    internal static class Diagnostics
+    public static class Diagnostics
     {
         private const string Category = "Scrutor";
 
@@ -24,10 +25,10 @@ namespace Scrutor.Analyzers
             true
         );
 
-        public static DiagnosticDescriptor TypeNotResolved { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor UnhandledSymbol { get; } = new DiagnosticDescriptor(
             "SCTR0003",
-            "Type could not be resolved",
-            "The indicated type could not be resolved",
+            "Symbol could not be handled",
+            "The indicated symbol could not be handled correctly",
             Category,
             DiagnosticSeverity.Warning,
             true

--- a/src/Scrutor.Analyzers/Diagnostics.cs
+++ b/src/Scrutor.Analyzers/Diagnostics.cs
@@ -34,9 +34,18 @@ namespace Scrutor.Analyzers
         );
 
         public static DiagnosticDescriptor NamespaceMustBeAString { get; } = new DiagnosticDescriptor(
-            "SCTR0003",
+            "SCTR0004",
             "Namespace must be a string",
             "The given namespace must be a constant string",
+            Category,
+            DiagnosticSeverity.Warning,
+            true
+        );
+
+        public static DiagnosticDescriptor DuplicateServiceDescriptorAttribute { get; } = new DiagnosticDescriptor(
+            "SCTR0005",
+            "Duplicate service descriptor attribute",
+            "Cannot have more than one service descriptor attribute for a given type",
             Category,
             DiagnosticSeverity.Warning,
             true

--- a/src/Scrutor.Analyzers/Diagnostics.cs
+++ b/src/Scrutor.Analyzers/Diagnostics.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Scrutor.Analyzers
+{
+    internal static class Diagnostics
+    {
+        private const string Category = "Scrutor";
+
+        public static DiagnosticDescriptor MustBeAnExpression { get; } = new DiagnosticDescriptor(
+            "SCTR0001",
+            "Must be a expression",
+            "Methods that will be analyzed statically must be an expression, blocks and variables are not allowed",
+            Category,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+        public static DiagnosticDescriptor MustBeTypeOf { get; } = new DiagnosticDescriptor(
+            "SCTR0002",
+            "Must use typeof",
+            "Method must be called with typeof, variables are not allowed",
+            Category,
+            DiagnosticSeverity.Error,
+            true
+        );
+
+        public static DiagnosticDescriptor TypeNotResolved { get; } = new DiagnosticDescriptor(
+            "SCTR0003",
+            "Type could not be resolved",
+            "The indicated type could not be resolved",
+            Category,
+            DiagnosticSeverity.Warning,
+            true
+        );
+
+        public static DiagnosticDescriptor NamespaceMustBeAString { get; } = new DiagnosticDescriptor(
+            "SCTR0003",
+            "Namespace must be a string",
+            "The given namespace must be a constant string",
+            Category,
+            DiagnosticSeverity.Warning,
+            true
+        );
+    }
+}

--- a/src/Scrutor.Analyzers/Helpers.cs
+++ b/src/Scrutor.Analyzers/Helpers.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Scrutor.Analyzers
+{
+    public static class Helpers
+    {
+        public static string GetFullMetadataName(ISymbol? s)
+        {
+            if (s == null || IsRootNamespace(s))
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder(s.MetadataName);
+            var last = s;
+
+            s = s.ContainingSymbol;
+
+            while (!IsRootNamespace(s))
+            {
+                if (s is ITypeSymbol && last is ITypeSymbol)
+                {
+                    sb.Insert(0, '+');
+                }
+                else
+                {
+                    sb.Insert(0, '.');
+                }
+
+                sb.Insert(0, s.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                //sb.Insert(0, s.MetadataName);
+                s = s.ContainingSymbol;
+            }
+
+            return sb.ToString();
+
+            static bool IsRootNamespace(ISymbol symbol)
+            {
+                INamespaceSymbol? s = null;
+                return (s = symbol as INamespaceSymbol) != null && s.IsGlobalNamespace;
+            }
+        }
+    }
+}

--- a/src/Scrutor.Analyzers/Helpers.cs
+++ b/src/Scrutor.Analyzers/Helpers.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Scrutor.Analyzers
@@ -112,10 +113,11 @@ namespace Scrutor.Analyzers
         private static Regex SpecialCharacterRemover = new Regex("[^\\w\\d]", RegexOptions.Compiled);
         public static string AssemblyVariableName(IAssemblySymbol symbol) => SpecialCharacterRemover.Replace(symbol.Identity.GetDisplayName(true), "");
 
-        public static IEnumerable<INamedTypeSymbol> GetBaseTypes(INamedTypeSymbol namedTypeSymbol)
+        public static IEnumerable<INamedTypeSymbol> GetBaseTypes(CSharpCompilation compilation, INamedTypeSymbol namedTypeSymbol)
         {
             while (namedTypeSymbol.BaseType != null)
             {
+                if (SymbolEqualityComparer.Default.Equals(namedTypeSymbol.BaseType, compilation.ObjectType)) yield break;
                 yield return namedTypeSymbol.BaseType;
                 namedTypeSymbol = namedTypeSymbol.BaseType;
             }

--- a/src/Scrutor.Analyzers/Helpers.cs
+++ b/src/Scrutor.Analyzers/Helpers.cs
@@ -52,13 +52,29 @@ namespace Scrutor.Analyzers
             }
 
             var sb = new StringBuilder(symbol.MetadataName);
-            if (symbol is INamedTypeSymbol namedTypeSymbol && (namedTypeSymbol.IsUnboundGenericType || namedTypeSymbol.IsGenericType && namedTypeSymbol.TypeArguments.All(z => z is ITypeParameterSymbol)))
+            if (symbol is INamedTypeSymbol namedTypeSymbol && (namedTypeSymbol.IsOpenGenericType() || namedTypeSymbol.IsGenericType))
             {
                 sb = new StringBuilder(symbol.Name);
-                sb.Append("<");
-                for (var i = 1; i < namedTypeSymbol.Arity-1; i++)
-                    sb.Append(",");
-                sb.Append(">");
+                if (namedTypeSymbol.IsOpenGenericType())
+                {
+                    sb.Append("<");
+                    for (var i = 1; i < namedTypeSymbol.Arity - 1; i++)
+                        sb.Append(",");
+                    sb.Append(">");
+                }
+                else
+                {
+                    sb.Append("<");
+                    for (var index = 0; index < namedTypeSymbol.TypeArguments.Length; index++)
+                    {
+                        var argument = namedTypeSymbol.TypeArguments[index];
+                        sb.Append(GetGenericDisplayName(argument));
+                        if (index < namedTypeSymbol.TypeArguments.Length -1)
+                        sb.Append(",");
+                    }
+
+                    sb.Append(">");
+                }
             }
 
             var last = symbol;

--- a/src/Scrutor.Analyzers/Internals/ClassFilter.cs
+++ b/src/Scrutor.Analyzers/Internals/ClassFilter.cs
@@ -1,0 +1,8 @@
+namespace Scrutor.Analyzers.Internals
+{
+    enum ClassFilter
+    {
+        All = 1,
+        PublicOnly = 2
+    }
+}

--- a/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
@@ -22,17 +22,13 @@ namespace Scrutor.Analyzers.Internals
     {
         public override string ToString() => "All";
     }
-    interface ICompiledAssemblyDescriptor : IAssemblyDescriptor
-    {
-        INamedTypeSymbol TypeFromAssembly { get; }
-    }
-    struct CompiledAssemblyDescriptor : ICompiledAssemblyDescriptor
+    struct CompiledAssemblyDescriptor : IAssemblyDescriptor
     {
         public INamedTypeSymbol TypeFromAssembly { get; }
         public CompiledAssemblyDescriptor(INamedTypeSymbol typeFromAssembly) => TypeFromAssembly = typeFromAssembly;
         public override string ToString() => Helpers.GetFullMetadataName(TypeFromAssembly);
     }
-    struct CompiledAssemblyDependenciesDescriptor : ICompiledAssemblyDescriptor
+    struct CompiledAssemblyDependenciesDescriptor : IAssemblyDescriptor
     {
         public INamedTypeSymbol TypeFromAssembly { get; }
         public CompiledAssemblyDependenciesDescriptor(INamedTypeSymbol typeFromAssembly) => TypeFromAssembly = typeFromAssembly;

--- a/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
@@ -15,7 +15,7 @@ namespace Scrutor.Analyzers.Internals
         {
             AssemblySymbol = assemblySymbol;
         }
-        public override string ToString() => "All";
+        public override string ToString() => Helpers.GetFullMetadataName(AssemblySymbol);
     }
 
     struct AllAssemblyDescriptor : IAssemblyDescriptor

--- a/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/IAssemblyDescriptor.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace Scrutor.Analyzers.Internals
+{
+    interface IAssemblyDescriptor
+    {
+    }
+
+    struct AssemblyDescriptor : IAssemblyDescriptor
+    {
+        public IAssemblySymbol AssemblySymbol { get; }
+
+        public AssemblyDescriptor(IAssemblySymbol assemblySymbol)
+        {
+            AssemblySymbol = assemblySymbol;
+        }
+        public override string ToString() => "All";
+    }
+
+    struct AllAssemblyDescriptor : IAssemblyDescriptor
+    {
+        public override string ToString() => "All";
+    }
+    interface ICompiledAssemblyDescriptor : IAssemblyDescriptor
+    {
+        INamedTypeSymbol TypeFromAssembly { get; }
+    }
+    struct CompiledAssemblyDescriptor : ICompiledAssemblyDescriptor
+    {
+        public INamedTypeSymbol TypeFromAssembly { get; }
+        public CompiledAssemblyDescriptor(INamedTypeSymbol typeFromAssembly) => TypeFromAssembly = typeFromAssembly;
+        public override string ToString() => Helpers.GetFullMetadataName(TypeFromAssembly);
+    }
+    struct CompiledAssemblyDependenciesDescriptor : ICompiledAssemblyDescriptor
+    {
+        public INamedTypeSymbol TypeFromAssembly { get; }
+        public CompiledAssemblyDependenciesDescriptor(INamedTypeSymbol typeFromAssembly) => TypeFromAssembly = typeFromAssembly;
+        public override string ToString() => Helpers.GetFullMetadataName(TypeFromAssembly);
+    }
+}

--- a/src/Scrutor.Analyzers/Internals/IServiceTypeDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/IServiceTypeDescriptor.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Scrutor.Analyzers.Internals
+{
+    interface IServiceTypeDescriptor { }
+
+    struct SelfServiceTypeDescriptor : IServiceTypeDescriptor { }
+
+    struct ImplementedInterfacesServiceTypeDescriptor : IServiceTypeDescriptor { }
+
+    struct MatchingInterfaceServiceTypeDescriptor : IServiceTypeDescriptor { }
+
+    struct ServiceTypeDescriptor : IServiceTypeDescriptor
+    {
+        public Type Type { get; }
+
+        public ServiceTypeDescriptor(Type type) => Type = type;
+    }
+    struct CompiledServiceTypeDescriptor : IServiceTypeDescriptor
+    {
+        public INamedTypeSymbol Type { get; }
+
+        public CompiledServiceTypeDescriptor(INamedTypeSymbol type) => Type = type;
+    }
+}

--- a/src/Scrutor.Analyzers/Internals/IServiceTypeDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/IServiceTypeDescriptor.cs
@@ -10,13 +10,7 @@ namespace Scrutor.Analyzers.Internals
     struct ImplementedInterfacesServiceTypeDescriptor : IServiceTypeDescriptor { }
 
     struct MatchingInterfaceServiceTypeDescriptor : IServiceTypeDescriptor { }
-
-    struct ServiceTypeDescriptor : IServiceTypeDescriptor
-    {
-        public Type Type { get; }
-
-        public ServiceTypeDescriptor(Type type) => Type = type;
-    }
+    struct UsingAttributeServiceTypeDescriptor : IServiceTypeDescriptor { }
     struct CompiledServiceTypeDescriptor : IServiceTypeDescriptor
     {
         public INamedTypeSymbol Type { get; }

--- a/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
@@ -47,4 +47,11 @@ namespace Scrutor.Analyzers.Internals
 
         public CompiledAssignableToAnyTypeFilterDescriptor(INamedTypeSymbol type) => Type = type;
     }
+
+    struct CompiledAbortTypeFilterDescriptor : ITypeFilterDescriptor
+    {
+        public INamedTypeSymbol Type { get; }
+
+        public CompiledAbortTypeFilterDescriptor(INamedTypeSymbol type) => Type = type;
+    }
 }

--- a/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Scrutor.Analyzers.Internals
@@ -9,39 +10,38 @@ namespace Scrutor.Analyzers.Internals
 
     struct NamespaceFilterDescriptor : ITypeFilterDescriptor
     {
-        public string Namespace { get; }
+        public IEnumerable<string> Namespaces { get; }
         public NamespaceFilter Filter { get; }
 
-        public NamespaceFilterDescriptor(NamespaceFilter filter, string @namespace)
+        public NamespaceFilterDescriptor(NamespaceFilter filter, IEnumerable<string> namespaces)
         {
             Filter = filter;
-            Namespace = @namespace;
+            Namespaces = namespaces;
         }
     }
 
-    struct AttributeFilterDescriptor : ITypeFilterDescriptor
-    {
-        public Type Attribute { get; }
-
-        public AttributeFilterDescriptor(Type attribute) => Attribute = attribute;
-    }
-    interface ICompiledTypeFilterDescriptor : ITypeFilterDescriptor
-    {
-        INamedTypeSymbol Type { get; }
-    }
-    struct CompiledAttributeFilterDescriptor : ITypeFilterDescriptor
+    struct CompiledWithAttributeFilterDescriptor : ITypeFilterDescriptor
     {
         public INamedTypeSymbol Attribute { get; }
 
-        public CompiledAttributeFilterDescriptor(INamedTypeSymbol attribute) => Attribute = attribute;
+        public CompiledWithAttributeFilterDescriptor(INamedTypeSymbol attribute) => Attribute = attribute;
     }
-    struct CompiledAssignableToTypeFilterDescriptor : ICompiledTypeFilterDescriptor
+
+    struct CompiledWithoutAttributeFilterDescriptor : ITypeFilterDescriptor
+    {
+        public INamedTypeSymbol Attribute { get; }
+
+        public CompiledWithoutAttributeFilterDescriptor(INamedTypeSymbol attribute) => Attribute = attribute;
+    }
+
+    struct CompiledAssignableToTypeFilterDescriptor : ITypeFilterDescriptor
     {
         public INamedTypeSymbol Type { get; }
 
         public CompiledAssignableToTypeFilterDescriptor(INamedTypeSymbol type) => Type = type;
     }
-    struct CompiledAssignableToAnyTypeFilterDescriptor : ICompiledTypeFilterDescriptor
+
+    struct CompiledAssignableToAnyTypeFilterDescriptor : ITypeFilterDescriptor
     {
         public INamedTypeSymbol Type { get; }
 

--- a/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
+++ b/src/Scrutor.Analyzers/Internals/ITypeFilterDescriptor.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Scrutor.Analyzers.Internals
+{
+    interface ITypeFilterDescriptor
+    {
+    }
+
+    struct NamespaceFilterDescriptor : ITypeFilterDescriptor
+    {
+        public string Namespace { get; }
+        public NamespaceFilter Filter { get; }
+
+        public NamespaceFilterDescriptor(NamespaceFilter filter, string @namespace)
+        {
+            Filter = filter;
+            Namespace = @namespace;
+        }
+    }
+
+    struct AttributeFilterDescriptor : ITypeFilterDescriptor
+    {
+        public Type Attribute { get; }
+
+        public AttributeFilterDescriptor(Type attribute) => Attribute = attribute;
+    }
+    interface ICompiledTypeFilterDescriptor : ITypeFilterDescriptor
+    {
+        INamedTypeSymbol Type { get; }
+    }
+    struct CompiledAttributeFilterDescriptor : ITypeFilterDescriptor
+    {
+        public INamedTypeSymbol Attribute { get; }
+
+        public CompiledAttributeFilterDescriptor(INamedTypeSymbol attribute) => Attribute = attribute;
+    }
+    struct CompiledAssignableToTypeFilterDescriptor : ICompiledTypeFilterDescriptor
+    {
+        public INamedTypeSymbol Type { get; }
+
+        public CompiledAssignableToTypeFilterDescriptor(INamedTypeSymbol type) => Type = type;
+    }
+    struct CompiledAssignableToAnyTypeFilterDescriptor : ICompiledTypeFilterDescriptor
+    {
+        public INamedTypeSymbol Type { get; }
+
+        public CompiledAssignableToAnyTypeFilterDescriptor(INamedTypeSymbol type) => Type = type;
+    }
+}

--- a/src/Scrutor.Analyzers/Internals/NamespaceFilter.cs
+++ b/src/Scrutor.Analyzers/Internals/NamespaceFilter.cs
@@ -1,6 +1,6 @@
 namespace Scrutor.Analyzers.Internals
 {
-    enum NamespaceFilter
+    public enum NamespaceFilter
     {
         Exact = 1,
         In = 2,

--- a/src/Scrutor.Analyzers/Internals/NamespaceFilter.cs
+++ b/src/Scrutor.Analyzers/Internals/NamespaceFilter.cs
@@ -1,0 +1,9 @@
+namespace Scrutor.Analyzers.Internals
+{
+    enum NamespaceFilter
+    {
+        Exact = 1,
+        In = 2,
+        NotIn = 3
+    }
+}

--- a/src/Scrutor.Analyzers/Scrutor.Analyzers.csproj
+++ b/src/Scrutor.Analyzers/Scrutor.Analyzers.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Register services using source generation and a fluent API.</Description>
+    <VersionPrefix>3.2.2</VersionPrefix>
+    <Authors>Kristian Hellang</Authors>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Scrutor</PackageId>
+    <PackageTags>Dependency;Injection;DI;Scanning;Conventions;Decoration</PackageTags>
+    <PackageProjectUrl>https://github.com/khellang/Scrutor</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/khellang/Scrutor</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AssemblyOriginatorKeyFile>../signing.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Only increase this value in case of incompatible API changes. -->
+    <AssemblyVersion>3.0.2.0</AssemblyVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <Compile Include="../Scrutor/Static/*.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Scrutor.Analyzers/Scrutor.Analyzers.csproj
+++ b/src/Scrutor.Analyzers/Scrutor.Analyzers.csproj
@@ -4,12 +4,13 @@
     <VersionPrefix>3.2.2</VersionPrefix>
     <Authors>Kristian Hellang</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>Scrutor</PackageId>
+    <PackageId>Scrutor.Analyzers</PackageId>
     <PackageTags>Dependency;Injection;DI;Scanning;Conventions;Decoration</PackageTags>
     <PackageProjectUrl>https://github.com/khellang/Scrutor</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,8 +21,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>../signing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- Only increase this value in case of incompatible API changes. -->
     <AssemblyVersion>3.0.2.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/Scrutor.Analyzers/StatementGeneration.cs
+++ b/src/Scrutor.Analyzers/StatementGeneration.cs
@@ -1,0 +1,123 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Scrutor.Analyzers
+{
+    static class StatementGeneration
+    {
+        private static MemberAccessExpressionSyntax Describe = MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            IdentifierName("ServiceDescriptor"),
+            IdentifierName("Describe")
+        );
+
+        private static InvocationExpressionSyntax GetPrivateType(string typeName)
+        {
+            return InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName("Type"),
+                        IdentifierName("GetType")
+                    )
+                )
+               .WithArgumentList(
+                    ArgumentList(
+                        SeparatedList<ArgumentSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Argument(
+                                    LiteralExpression(
+                                        SyntaxKind.StringLiteralExpression,
+                                        Literal(typeName)
+                                    )
+                                ),
+                                Token(SyntaxKind.CommaToken),
+                                Argument(
+                                    LiteralExpression(
+                                        SyntaxKind.TrueLiteralExpression
+                                    )
+                                )
+                            }
+                        )
+                    )
+                );
+        }
+
+        public static InvocationExpressionSyntax GenerateServiceFactory(
+            NameSyntax strategyName,
+            NameSyntax serviceCollectionName,
+            INamedTypeSymbol serviceType,
+            INamedTypeSymbol implementationType,
+            ExpressionSyntax lifetime
+        )
+        {
+            var serviceTypeExpression = GetTypeOfExpression(serviceType);
+            var implementationTypeExpression = SimpleLambdaExpression(Parameter(Identifier("_")))
+               .WithExpressionBody(
+                    InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("_"), IdentifierName("GetRequiredService")))
+                       .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(GetTypeOfExpression(implementationType)))))
+                );
+            return GenerateServiceType(strategyName, serviceCollectionName, serviceTypeExpression, implementationTypeExpression, lifetime);
+        }
+
+        public static InvocationExpressionSyntax GenerateServiceType(
+            NameSyntax strategyName,
+            NameSyntax serviceCollectionName,
+            INamedTypeSymbol serviceType,
+            INamedTypeSymbol implementationType,
+            ExpressionSyntax lifetime
+        )
+        {
+            var serviceTypeExpression = GetTypeOfExpression(serviceType);
+            var implementationTypeExpression = GetTypeOfExpression(implementationType);
+            return GenerateServiceType(strategyName, serviceCollectionName, serviceTypeExpression, implementationTypeExpression, lifetime);
+        }
+
+        private static InvocationExpressionSyntax GenerateServiceType(
+            NameSyntax strategyName,
+            NameSyntax serviceCollectionName,
+            ExpressionSyntax serviceTypeExpression,
+            ExpressionSyntax implementationTypeExpression,
+            ExpressionSyntax lifetime
+        ) => InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    strategyName,
+                    IdentifierName("Apply")
+                )
+            )
+           .WithArgumentList(
+                ArgumentList(
+                    SeparatedList(
+                        new[]
+                        {
+                            Argument(serviceCollectionName),
+                            Argument(
+                                InvocationExpression(Describe)
+                                   .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList(
+                                                new[]
+                                                {
+                                                    Argument(serviceTypeExpression),
+                                                    Argument(implementationTypeExpression),
+                                                    Argument(lifetime)
+                                                }
+                                            )
+                                        )
+                                    )
+                            )
+                        }
+                    )
+                )
+            );
+
+        private static ExpressionSyntax GetTypeOfExpression(INamedTypeSymbol type) => type.DeclaredAccessibility == Accessibility.Public
+            ? TypeOfExpression(
+                ParseTypeName(type.ToDisplayString()) // might be a better way to do this
+            ) as ExpressionSyntax
+            : GetPrivateType(type.ToDisplayString());
+    }
+}

--- a/src/Scrutor.Analyzers/StatementGeneration.cs
+++ b/src/Scrutor.Analyzers/StatementGeneration.cs
@@ -151,7 +151,7 @@ namespace Scrutor.Analyzers
             if (SymbolEqualityComparer.Default.Equals(assignableToType, type)) return true;
             if (assignableToType.Arity > 0 && assignableToType.IsUnboundGenericType)
             {
-                var matchingBaseTypes = Helpers.GetBaseTypes(type)
+                var matchingBaseTypes = Helpers.GetBaseTypes(compilation, type)
                     .Select(z => z.IsGenericType ? z.IsUnboundGenericType ? z : z.ConstructUnboundGenericType() : null!)
                     .Where(z => z is not null)
                     .Where(symbol => compilation.HasImplicitConversion(symbol, assignableToType));
@@ -185,7 +185,7 @@ namespace Scrutor.Analyzers
                 }
                 else
                 {
-                    var baseType = Helpers.GetBaseTypes(type).FirstOrDefault(z => z.IsGenericType && compilation.HasImplicitConversion(z, type));
+                    var baseType = Helpers.GetBaseTypes(compilation, type).FirstOrDefault(z => z.IsGenericType && compilation.HasImplicitConversion(z, type));
                     if (baseType == null)
                     {
                         baseType = type.AllInterfaces.FirstOrDefault(z => z.IsGenericType && compilation.HasImplicitConversion(z, type));

--- a/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
+++ b/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Scrutor.Analyzers.Internals;
+using Scrutor.Static;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Scrutor.Analyzers
+{
+    [Generator]
+    public class StaticScrutorGenerator : ISourceGenerator
+    {
+        public void Initialize(InitializationContext context)
+        {
+            context.RegisterForSyntaxNotifications(() => new StaticScrutorSyntaxReceiver());
+        }
+
+        static SourceText staticScanSourceText = SourceText.From(
+            @"
+using System;
+using System.Runtime.CompilerServices;
+using Scrutor;
+using Scrutor.Static;
+namespace Microsoft.Extensions.DependencyInjection
+{
+    internal static class StaticScrutorExtensions
+    {
+        public static IServiceCollection ScanStatic(
+            this IServiceCollection services,
+            Action<ICompiledAssemblySelector> action,
+	        [CallerFilePathAttribute] string filePath = """",
+	        [CallerMemberName] string memberName = """",
+	        [CallerLineNumberAttribute] int lineNumber = 0
+        )
+        {
+            return PopulateExtensions.Populate(services, RegistrationStrategy.Append, filePath, memberName, lineNumber);
+        }
+
+        public static IServiceCollection ScanStatic(
+            this IServiceCollection services,
+            Action<ICompiledAssemblySelector> action,
+            RegistrationStrategy strategy,
+	        [CallerFilePathAttribute] string filePath = """",
+	        [CallerMemberName] string memberName = """",
+	        [CallerLineNumberAttribute] int lineNumber = 0
+        )
+        {
+            return PopulateExtensions.Populate(services, strategy, filePath, memberName, lineNumber);
+        }
+    }
+}
+",
+            Encoding.UTF8
+        );
+
+        static SourceText populateSourceText = SourceText.From(
+            @"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, string filePath, string memberName, int lineNumber)
+        {
+            return services;
+        }
+    }
+}
+",
+            Encoding.UTF8
+        );
+
+        public void Execute(SourceGeneratorContext context)
+        {
+            if (!(context.SyntaxReceiver is StaticScrutorSyntaxReceiver syntaxReceiver) || syntaxReceiver.ScanStaticExpressions.Count == 0)
+            {
+                return;
+            }
+
+            var compilation = (context.Compilation as CSharpCompilation)!;
+            var compilationWithMethod = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(staticScanSourceText), CSharpSyntaxTree.ParseText(populateSourceText));
+
+            context.AddSource("Microsoft.Extensions.DependencyInjection.StaticScrutorExtension.cs", staticScanSourceText);
+
+            var groups =
+                new List<(
+                    ExpressionSyntax expression,
+                    string filePath,
+                    string memberName,
+                    int lineNumber,
+                    List<IAssemblyDescriptor> assemblies,
+                    List<ITypeFilterDescriptor> typeFilters,
+                    List<IServiceTypeDescriptor> serviceTypes,
+                    ClassFilter classFilter,
+                    ExpressionSyntax lifetime
+                    )>();
+
+            foreach (var rootExpression in syntaxReceiver.ScanStaticExpressions)
+            {
+                var semanticModel = compilationWithMethod.GetSemanticModel(rootExpression.SyntaxTree);
+
+                var diagnostics = compilationWithMethod.GetDiagnostics();
+                var assemblies = new List<IAssemblyDescriptor>();
+                var typeFilters = new List<ITypeFilterDescriptor>();
+                var serviceTypes = new List<IServiceTypeDescriptor>();
+                var classFilter = ClassFilter.All;
+                var lifetimeExpressionSyntax =
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName("ServiceLifetime"),
+                        IdentifierName("Transient")
+                    );
+
+                DataHelpers.HandleInvocationExpressionSyntax(
+                    compilationWithMethod,
+                    semanticModel,
+                    rootExpression,
+                    assemblies,
+                    typeFilters,
+                    serviceTypes,
+                    ref classFilter,
+                    ref lifetimeExpressionSyntax
+                );
+
+                var containingMethod = rootExpression.Ancestors().OfType<MethodDeclarationSyntax>().First();
+
+                var methodCallSyntax = rootExpression.Ancestors()
+                   .OfType<InvocationExpressionSyntax>()
+                   .First(
+                        ies => ies.Expression is MemberAccessExpressionSyntax mae
+                         && mae.Name.ToFullString().EndsWith("ScanStatic", StringComparison.Ordinal)
+                    );
+
+                groups.Add(
+                    (
+                        rootExpression,
+                        rootExpression.SyntaxTree.FilePath,
+                        containingMethod.Identifier.Text,
+                        // line numbers here are 1 based
+                        methodCallSyntax.SyntaxTree.GetText().Lines.First(z => z.Span.IntersectsWith(methodCallSyntax.Span)).LineNumber + 1,
+                        assemblies,
+                        typeFilters,
+                        serviceTypes,
+                        classFilter,
+                        lifetimeExpressionSyntax
+                    )
+                );
+
+                if (serviceTypes.Count == 0)
+                {
+                    serviceTypes.Add(new SelfServiceTypeDescriptor());
+                }
+            }
+
+            var allNamedTypes = TypeSymbolVisitor.GetTypes(compilationWithMethod);
+
+            var strategyName = IdentifierName("strategy");
+            var serviceCollectionName = IdentifierName("services");
+            var lineNumberIdentifier = IdentifierName("lineNumber");
+            var filePathIdentifier = IdentifierName("filePath");
+            var block = Block();
+
+            var switchStatement = SwitchStatement(lineNumberIdentifier);
+            foreach (var lineGrouping in groups.GroupBy(z => z.lineNumber))
+            {
+                var innerBlock = Block();
+                var blocks = new List<(string filePath, string memberName, BlockSyntax block)>();
+                foreach (var (expression, filePath, memberName, lineNumber, assemblies, typeFilters, serviceTypes, classFilter, lifetime) in lineGrouping)
+                {
+                    var types = NarrowListOfTypes(assemblies, allNamedTypes, compilationWithMethod, classFilter, typeFilters);
+
+                    var localBlock = GenerateDescriptors(
+                        types,
+                        serviceTypes,
+                        innerBlock,
+                        strategyName,
+                        serviceCollectionName,
+                        lifetime
+                    );
+
+                    blocks.Add((filePath, memberName, localBlock));
+                }
+
+                static SwitchSectionSyntax CreateNestedSwitchSections<T>(
+                    IReadOnlyList<(string filePath, string memberName, BlockSyntax block)> blocks,
+                    NameSyntax identifier,
+                    Func<(string filePath, string memberName, BlockSyntax block), T> regroup,
+                    Func<IGrouping<T, (string filePath, string memberName, BlockSyntax block)>, SwitchSectionSyntax> next,
+                    Func<T, LiteralExpressionSyntax> literalFactory
+                )
+                {
+                    if (blocks.Count == 1)
+                    {
+                        var (_, _, localBlock) = blocks[0];
+                        return SwitchSection()
+                           .AddStatements(localBlock.Statements.ToArray())
+                           .AddStatements(BreakStatement());
+                    }
+
+                    var section = SwitchStatement(identifier);
+                    foreach (var item in blocks.GroupBy(regroup))
+                    {
+                        section = section
+                           .AddSections(
+                                next(item)
+                                   .AddLabels(
+                                        CaseSwitchLabel(literalFactory(item.Key))
+                                    )
+                            );
+                    }
+
+                    return SwitchSection().AddStatements(section, BreakStatement());
+                }
+
+                var lineSwitchSection = CreateNestedSwitchSections(
+                        blocks,
+                        IdentifierName("filePath"),
+                        x => x.filePath,
+                        GenerateFilePathSwitchStatement,
+                        value =>
+                            LiteralExpression(
+                                SyntaxKind.StringLiteralExpression,
+                                Literal(value)
+                            )
+                    )
+                   .AddLabels(
+                        CaseSwitchLabel(
+                            LiteralExpression(
+                                SyntaxKind.NumericLiteralExpression,
+                                Literal(lineGrouping.Key)
+                            )
+                        )
+                    );
+
+                static SwitchSectionSyntax GenerateFilePathSwitchStatement(
+                    IGrouping<string, (string filePath, string memberName, BlockSyntax block)> innerGroup
+                ) => CreateNestedSwitchSections(
+                    innerGroup.ToArray(),
+                    IdentifierName("memberName"),
+                    x => x.memberName,
+                    GenerateMemberNameSwitchStatement,
+                    value =>
+                        LiteralExpression(
+                            SyntaxKind.StringLiteralExpression,
+                            Literal(value)
+                        )
+                );
+
+                static SwitchSectionSyntax GenerateMemberNameSwitchStatement(
+                    IGrouping<string, (string filePath, string memberName, BlockSyntax block)> innerGroup
+                ) => SwitchSection()
+                   .AddLabels(
+                        CaseSwitchLabel(
+                            LiteralExpression(
+                                SyntaxKind.StringLiteralExpression,
+                                Literal(innerGroup.Key)
+                            )
+                        )
+                    )
+                   .AddStatements(innerGroup.FirstOrDefault().block?.Statements.ToArray() ?? Array.Empty<StatementSyntax>())
+                   .AddStatements(BreakStatement());
+
+
+                switchStatement = switchStatement.AddSections(lineSwitchSection);
+            }
+
+            {
+                var root = CSharpSyntaxTree.ParseText(populateSourceText).GetCompilationUnitRoot();
+                var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+
+                root = root.ReplaceNode(method, method.WithBody(block.AddStatements(switchStatement).AddStatements(method.Body!.Statements.ToArray())));
+
+                context.AddSource("Scrutor.Static.Populate.cs", root.NormalizeWhitespace().GetText());
+            }
+        }
+
+        private static BlockSyntax GenerateDescriptors(
+            ImmutableArray<INamedTypeSymbol> types,
+            List<IServiceTypeDescriptor> serviceTypes,
+            BlockSyntax innerBlock,
+            IdentifierNameSyntax strategyName,
+            IdentifierNameSyntax serviceCollectionName,
+            ExpressionSyntax lifetime
+        )
+        {
+            var asSelf = serviceTypes.OfType<SelfServiceTypeDescriptor>().Any();
+            var asImplementedInterfaces = serviceTypes.OfType<ImplementedInterfacesServiceTypeDescriptor>().Any();
+            var asMatchingInterface = serviceTypes.OfType<MatchingInterfaceServiceTypeDescriptor>().Any();
+            if (!asSelf && !asImplementedInterfaces && !asMatchingInterface)
+                asSelf = true;
+            foreach (var type in types)
+            {
+                if (asSelf)
+                {
+                    innerBlock = innerBlock.AddStatements(
+                        ExpressionStatement(
+                            StatementGeneration.GenerateServiceType(
+                                strategyName,
+                                serviceCollectionName,
+                                type,
+                                type,
+                                lifetime
+                            )
+                        )
+                    );
+
+                    if (asMatchingInterface)
+                    {
+                        var name = $"I{type.Name}";
+                        var @interface = type.AllInterfaces.FirstOrDefault(z => z.Name == name);
+                        if (@interface is not null)
+                        {
+                            innerBlock = innerBlock.AddStatements(
+                                ExpressionStatement(
+                                    StatementGeneration.GenerateServiceFactory(
+                                        strategyName,
+                                        serviceCollectionName,
+                                        @interface,
+                                        type,
+                                        lifetime
+                                    )
+                                )
+                            );
+                        }
+                    }
+                    else if (asImplementedInterfaces)
+                    {
+                        foreach (var @interface in type.AllInterfaces)
+                        {
+                            innerBlock = innerBlock.AddStatements(
+                                ExpressionStatement(
+                                    StatementGeneration.GenerateServiceFactory(
+                                        strategyName,
+                                        serviceCollectionName,
+                                        @interface,
+                                        type,
+                                        lifetime
+                                    )
+                                )
+                            );
+                        }
+                    }
+                }
+                else
+                {
+                    if (asMatchingInterface)
+                    {
+                        var name = $"I{type.Name}";
+                        var @interface = type.AllInterfaces.FirstOrDefault(z => z.Name == name);
+                        if (@interface is not null)
+                        {
+                            innerBlock = innerBlock.AddStatements(
+                                ExpressionStatement(
+                                    StatementGeneration.GenerateServiceType(
+                                        strategyName,
+                                        serviceCollectionName,
+                                        @interface,
+                                        type,
+                                        lifetime
+                                    )
+                                )
+                            );
+                        }
+                    }
+                    else if (asImplementedInterfaces)
+                    {
+                        foreach (var @interface in type.AllInterfaces)
+                        {
+                            innerBlock = innerBlock.AddStatements(
+                                ExpressionStatement(
+                                    StatementGeneration.GenerateServiceType(
+                                        strategyName,
+                                        serviceCollectionName,
+                                        @interface,
+                                        type,
+                                        lifetime
+                                    )
+                                )
+                            );
+                        }
+                    }
+                }
+            }
+
+            return innerBlock;
+        }
+
+        static ImmutableArray<INamedTypeSymbol> NarrowListOfTypes(
+            List<IAssemblyDescriptor> assemblies,
+            ImmutableArray<INamedTypeSymbol> iNamedTypeSymbols,
+            CSharpCompilation cSharpCompilation,
+            ClassFilter classFilter,
+            List<ITypeFilterDescriptor> typeFilters
+        )
+        {
+            var types = assemblies.OfType<AllAssemblyDescriptor>().Any()
+                ? iNamedTypeSymbols
+                : TypeSymbolVisitor.GetTypes(
+                    cSharpCompilation,
+                    assemblies
+                       .OfType<ICompiledAssemblyDescriptor>()
+                       .Select(z => z.TypeFromAssembly.ContainingAssembly)
+                       .Distinct(SymbolEqualityComparer.Default)
+                );
+
+            if (classFilter == ClassFilter.PublicOnly)
+            {
+                types = types.RemoveAll(symbol => symbol.DeclaredAccessibility == Accessibility.Public);
+            }
+
+            foreach (var filter in typeFilters.OfType<CompiledAssignableToTypeFilterDescriptor>())
+            {
+                types = types.RemoveAll(
+                    toSymbol => SymbolEqualityComparer.Default.Equals(filter.Type, toSymbol) || !cSharpCompilation.HasImplicitConversion(toSymbol, filter.Type)
+                );
+            }
+
+            var anyFilters = typeFilters.OfType<CompiledAssignableToAnyTypeFilterDescriptor>().ToArray();
+            if (anyFilters.Length > 0)
+            {
+                types = types.RemoveAll(
+                    toSymbol => anyFilters.Any(
+                        filter => SymbolEqualityComparer.Default.Equals(filter.Type, toSymbol) || cSharpCompilation.HasImplicitConversion(toSymbol, filter.Type)
+                    )
+                );
+            }
+
+            foreach (var filter in typeFilters.OfType<NamespaceFilterDescriptor>())
+            {
+                types = types.RemoveAll(
+                    toSymbol =>
+                        filter.Filter switch
+                        {
+                            NamespaceFilter.Exact => toSymbol.ContainingNamespace.ToDisplayString() != filter.Namespace,
+                            NamespaceFilter.In => !toSymbol.ContainingNamespace.ToDisplayString().StartsWith(filter.Namespace, StringComparison.Ordinal),
+                            NamespaceFilter.NotIn => toSymbol.ContainingNamespace.ToDisplayString().StartsWith(filter.Namespace, StringComparison.Ordinal),
+                            _ => true
+                        }
+                );
+            }
+
+            // foreach (var filter in typeFilters.OfType<CompiledAttributeFilterDescriptor>())
+            // {
+            // }
+            return types;
+        }
+    }
+}

--- a/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
+++ b/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
@@ -369,7 +369,8 @@ namespace Scrutor.Static
                     {
                         // If there is no syntax it is probably not our code
                         if (duplicate.ApplicationSyntaxReference == null) continue;
-                        context.ReportDiagnostic(Diagnostic.Create(Diagnostics.DuplicateServiceDescriptorAttribute, Location.Create(duplicate.ApplicationSyntaxReference.SyntaxTree, duplicate.ApplicationSyntaxReference.Span)));
+                        context.ReportDiagnostic(Diagnostic.Create(Diagnostics.DuplicateServiceDescriptorAttribute,
+                            Location.Create(duplicate.ApplicationSyntaxReference.SyntaxTree, duplicate.ApplicationSyntaxReference.Span)));
                     }
 
                     foreach (var attribute in attributeDataElements)
@@ -689,6 +690,13 @@ namespace Scrutor.Static
             if (classFilter == ClassFilter.PublicOnly)
             {
                 types = types.RemoveAll(symbol => symbol.DeclaredAccessibility != Accessibility.Public);
+            }
+
+            // Ran into a filter we couldn't handle, so we bail out and let the diagnostics handle things.
+            if (typeFilters.OfType<CompiledAbortTypeFilterDescriptor>().Any())
+            {
+                types = types.Clear();
+                return types;
             }
 
             foreach (var filter in typeFilters.OfType<CompiledAssignableToTypeFilterDescriptor>())

--- a/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
+++ b/src/Scrutor.Analyzers/StaticScrutorGenerator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
 	        [CallerLineNumberAttribute] int lineNumber = 0
         )
         {
-            return PopulateExtensions.Populate(services, RegistrationStrategy.Append, AssemblyLoadContext.CurrentContextualReflectionContext ?? AssemblyLoadContext.GetLoadContext(typeof(StaticScrutorExtensions).Assembly) ?? AssemblyLoadContext.Default, filePath, memberName, lineNumber);
+            return PopulateExtensions.Populate(services, RegistrationStrategy.Append, AssemblyLoadContext.GetLoadContext(typeof(StaticScrutorExtensions).Assembly) ?? AssemblyLoadContext.Default, filePath, memberName, lineNumber);
         }
 
         public static IServiceCollection ScanStatic(
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
 	        [CallerLineNumberAttribute] int lineNumber = 0
         )
         {
-            return PopulateExtensions.Populate(services, strategy, AssemblyLoadContext.CurrentContextualReflectionContext ?? AssemblyLoadContext.GetLoadContext(typeof(StaticScrutorExtensions).Assembly) ?? AssemblyLoadContext.Default, filePath, memberName, lineNumber);
+            return PopulateExtensions.Populate(services, strategy, AssemblyLoadContext.GetLoadContext(typeof(StaticScrutorExtensions).Assembly) ?? AssemblyLoadContext.Default, filePath, memberName, lineNumber);
         }
 
         public static IServiceCollection ScanStatic(

--- a/src/Scrutor.Analyzers/StaticScrutorSyntaxReceiver.cs
+++ b/src/Scrutor.Analyzers/StaticScrutorSyntaxReceiver.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Scrutor.Analyzers
+{
+    internal class StaticScrutorSyntaxReceiver : ISyntaxReceiver
+    {
+        public List<ExpressionSyntax> ScanStaticExpressions { get; } = new List<ExpressionSyntax>();
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is InvocationExpressionSyntax ies)
+            {
+                if (ies.Expression is MemberAccessExpressionSyntax mae
+                 && mae.Name.ToFullString().EndsWith("ScanStatic", StringComparison.Ordinal)
+                 && ies.ArgumentList.Arguments.Count is 1 or 2)
+                {
+                    ScanStaticExpressions.Add(ies.ArgumentList.Arguments[0].Expression);
+                }
+            }
+        }
+    }
+}

--- a/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
+++ b/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
@@ -17,14 +17,6 @@ namespace Scrutor.Analyzers
             return visitor.GetTypes();
         }
 
-        public static ImmutableArray<INamedTypeSymbol> GetTypes(CSharpCompilation compilation, IEnumerable<MetadataReference> references)
-        {
-            var visitor = new TypeSymbolVisitor();
-            foreach (var symbol in references.Select(compilation.GetAssemblyOrModuleSymbol).Where(z => z != null))
-                symbol?.Accept(visitor);
-            return visitor.GetTypes();
-        }
-
         public static ImmutableArray<INamedTypeSymbol> GetTypes(CSharpCompilation compilation, IEnumerable<ISymbol?> symbols)
         {
             var visitor = new TypeSymbolVisitor();

--- a/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
+++ b/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
@@ -48,18 +48,19 @@ namespace Scrutor.Analyzers
 
         public override void VisitAssembly(IAssemblySymbol symbol)
         {
-            Accept(symbol.Modules);
+            symbol.GlobalNamespace.Accept(this);
         }
 
         public override void VisitNamedType(INamedTypeSymbol symbol)
         {
             if (symbol.TypeKind == TypeKind.Class || symbol.TypeKind == TypeKind.Delegate || symbol.TypeKind == TypeKind.Struct)
             {
-                if (symbol.IsAbstract) return;
+                if (symbol.IsAbstract || !symbol.CanBeReferencedByName) return;
                 _types.Add(symbol);
             }
+            Accept(symbol.GetMembers());
         }
 
-        public ImmutableArray<INamedTypeSymbol> GetTypes() => _types.ToImmutableArray();
+        public ImmutableArray<INamedTypeSymbol> GetTypes() => _types.Distinct(SymbolEqualityComparer.Default).OfType<INamedTypeSymbol>().ToImmutableArray();
     }
 }

--- a/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
+++ b/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Scrutor.Analyzers
+{
+    class TypeSymbolVisitor : SymbolVisitor
+    {
+        public static ImmutableArray<INamedTypeSymbol> GetTypes(CSharpCompilation compilation)
+        {
+            var visitor = new TypeSymbolVisitor();
+            visitor.VisitNamespace(compilation.GlobalNamespace);
+            foreach (var symbol in compilation.References.Select(compilation.GetAssemblyOrModuleSymbol).Where(z => z != null))
+                symbol?.Accept(visitor);
+            return visitor.GetTypes();
+        }
+
+        public static ImmutableArray<INamedTypeSymbol> GetTypes(CSharpCompilation compilation, IEnumerable<MetadataReference> references)
+        {
+            var visitor = new TypeSymbolVisitor();
+            foreach (var symbol in references.Select(compilation.GetAssemblyOrModuleSymbol).Where(z => z != null))
+                symbol?.Accept(visitor);
+            return visitor.GetTypes();
+        }
+
+        public static ImmutableArray<INamedTypeSymbol> GetTypes(CSharpCompilation compilation, IEnumerable<ISymbol?> symbols)
+        {
+            var visitor = new TypeSymbolVisitor();
+            visitor.Accept(symbols);
+            return visitor.GetTypes();
+        }
+
+        private readonly List<INamedTypeSymbol> _types = new List<INamedTypeSymbol>();
+
+        private void Accept<T>(IEnumerable<T> members)
+            where T : ISymbol?
+        {
+            foreach (var member in members)
+                member?.Accept(this);
+        }
+
+        public override void VisitNamespace(INamespaceSymbol symbol)
+        {
+            Accept(symbol.GetMembers());
+        }
+
+        public override void VisitAssembly(IAssemblySymbol symbol)
+        {
+            Accept(symbol.Modules);
+        }
+
+        public override void VisitNamedType(INamedTypeSymbol symbol)
+        {
+            if (symbol.TypeKind == TypeKind.Class || symbol.TypeKind == TypeKind.Delegate || symbol.TypeKind == TypeKind.Struct)
+            {
+                _types.Add(symbol);
+            }
+        }
+
+        public ImmutableArray<INamedTypeSymbol> GetTypes() => _types.ToImmutableArray();
+    }
+}

--- a/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
+++ b/src/Scrutor.Analyzers/TypeSymbolVisitor.cs
@@ -55,6 +55,7 @@ namespace Scrutor.Analyzers
         {
             if (symbol.TypeKind == TypeKind.Class || symbol.TypeKind == TypeKind.Delegate || symbol.TypeKind == TypeKind.Struct)
             {
+                if (symbol.IsAbstract) return;
                 _types.Add(symbol);
             }
         }

--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Scrutor;
 
-// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class ServiceCollectionExtensions
@@ -314,13 +313,13 @@ namespace Microsoft.Extensions.DependencyInjection
         private static ServiceDescriptor Decorate<TService>(this ServiceDescriptor descriptor, Func<TService, IServiceProvider, TService> decorator)
         {
             // TODO: Annotate TService with notnull when preview 8 is out.
-            return descriptor.WithFactory(provider => decorator((TService) provider.GetInstance(descriptor), provider)!);
+            return descriptor.WithFactory(provider => decorator((TService)provider.GetInstance(descriptor), provider)!);
         }
 
         private static ServiceDescriptor Decorate<TService>(this ServiceDescriptor descriptor, Func<TService, TService> decorator)
         {
             // TODO: Annotate TService with notnull when preview 8 is out.
-            return descriptor.WithFactory(provider => decorator((TService) provider.GetInstance(descriptor))!);
+            return descriptor.WithFactory(provider => decorator((TService)provider.GetInstance(descriptor))!);
         }
 
         private static ServiceDescriptor Decorate(this ServiceDescriptor descriptor, Type decoratorType)

--- a/src/Scrutor/ServiceCollectionExtensions.Scanning.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Scanning.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Scrutor;
 
-// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class ServiceCollectionExtensions

--- a/src/Scrutor/ServiceDescriptorAttribute.cs
+++ b/src/Scrutor/ServiceDescriptorAttribute.cs
@@ -9,6 +9,8 @@ namespace Scrutor
     {
         public ServiceDescriptorAttribute() : this(null) { }
 
+        public ServiceDescriptorAttribute(ServiceLifetime lifetime) : this(null, lifetime) { }
+
         public ServiceDescriptorAttribute(Type? serviceType) : this(serviceType, ServiceLifetime.Transient) { }
 
         public ServiceDescriptorAttribute(Type? serviceType, ServiceLifetime lifetime)

--- a/src/Scrutor/Static/ICompiledAssemblySelector.cs
+++ b/src/Scrutor/Static/ICompiledAssemblySelector.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Scrutor.Static
+{
+    public interface ICompiledAssemblySelector
+    {
+        /// <summary>
+        /// Will scan for types from this assembly at compile time.
+        /// </summary>
+        ICompiledImplementationTypeSelector FromAssembly();
+
+        /// <summary>
+        /// Will scan for types from all metadata assembly at compile time.
+        /// </summary>
+        ICompiledImplementationTypeSelector FromAssemblies();
+
+        /// <summary>
+        /// Will load and scan from given types assembly
+        /// </summary>
+        ICompiledImplementationTypeSelector FromAssemblyDependenciesOf<T>();
+
+        /// <summary>
+        /// Will load and scan from given types assembly
+        /// </summary>
+        ICompiledImplementationTypeSelector FromAssemblyDependenciesOf(Type type);
+
+        /// <summary>
+        /// Will scan for types from the assembly of type <typeparamref name="T" />.
+        /// </summary>
+        /// <typeparam name="T">The type in which assembly that should be scanned.</typeparam>
+        ICompiledImplementationTypeSelector FromAssemblyOf<T>();
+
+        /// <summary>
+        /// Will scan for types from the assembly of type.
+        /// </summary>
+        ICompiledImplementationTypeSelector FromAssemblyOf(Type type);
+    }
+}

--- a/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
+++ b/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
@@ -11,13 +11,13 @@ namespace Scrutor.Static
         ICompiledImplementationTypeFilter AssignableTo(Type type);
         ICompiledImplementationTypeFilter AssignableToAny(Type first, params Type[] types);
         ICompiledImplementationTypeFilter InExactNamespaceOf<T>();
-        ICompiledImplementationTypeFilter InExactNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter InExactNamespaceOf(Type first);
         ICompiledImplementationTypeFilter InExactNamespaces(string first, params string[] namespaces);
         ICompiledImplementationTypeFilter InNamespaceOf<T>();
-        ICompiledImplementationTypeFilter InNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter InNamespaceOf(Type first);
         ICompiledImplementationTypeFilter InNamespaces(string first, params string[] namespaces);
         ICompiledImplementationTypeFilter NotInNamespaceOf<T>();
-        ICompiledImplementationTypeFilter NotInNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter NotInNamespaceOf(Type first);
         ICompiledImplementationTypeFilter NotInNamespaces(string first, params string[] namespaces);
         ICompiledImplementationTypeFilter WithAttribute<T>();
         ICompiledImplementationTypeFilter WithoutAttribute<T>();

--- a/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
+++ b/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
@@ -7,19 +7,116 @@ namespace Scrutor.Static
 {
     public interface ICompiledImplementationTypeFilter
     {
+        /// <summary>
+        /// Will match all types that are assignable to <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type that should be assignable from the matching types.</typeparam>
         ICompiledImplementationTypeFilter AssignableTo<T>();
+
+        /// <summary>
+        /// Will match all types that are assignable to the specified <paramref name="type" />.
+        /// </summary>
+        /// <param name="type">The type that should be assignable from the matching types.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="type"/> argument is <c>null</c>.</exception>
         ICompiledImplementationTypeFilter AssignableTo(Type type);
+
+        /// <summary>
+        /// Will match all types that are assignable to any of the specified <paramref name="types" />.
+        /// </summary>
+        /// <param name="first">The first type that should be assignable from the matching types.</param>
+        /// <param name="types">The types that should be assignable from the matching types.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="types"/> argument is <c>null</c>.</exception>
         ICompiledImplementationTypeFilter AssignableToAny(Type first, params Type[] types);
+
+        /// <summary>
+        /// Will match all types in the exact same namespace as the type <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">The type in the namespace to include</typeparam>
         ICompiledImplementationTypeFilter InExactNamespaceOf<T>();
-        ICompiledImplementationTypeFilter InExactNamespaceOf(Type first);
+
+        /// <summary>
+        /// Will match all types in the exact same namespace as the type <paramref name="types"/>
+        /// </summary>
+        /// <param name="first">The first type in the namespaces to include.</param>
+        /// <param name="types">The types in the namespaces to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="types"/> argument is <c>null</c>.</exception>
+        ICompiledImplementationTypeFilter InExactNamespaceOf(Type first, params Type[] types);
+
+        /// <summary>
+        /// Will match all types in the exact same namespace as the type <paramref name="namespaces"/>
+        /// </summary>
+        /// <param name="first">The first namespace to include.</param>
+        /// <param name="namespaces">The namespace to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="namespaces"/> argument is <c>null</c>.</exception>
         ICompiledImplementationTypeFilter InExactNamespaces(string first, params string[] namespaces);
+
+        /// <summary>
+        /// Will match all types in the same namespace as the type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">A type inside the namespace to include.</typeparam>
         ICompiledImplementationTypeFilter InNamespaceOf<T>();
-        ICompiledImplementationTypeFilter InNamespaceOf(Type first);
+
+        /// <summary>
+        /// Will match all types in any of the namespaces of the <paramref name="types" /> specified.
+        /// </summary>
+        /// <param name="first">The first type in the namespaces to include.</param>
+        /// <param name="types">The types in the namespaces to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="types"/> argument is <c>null</c>.</exception>
+        ICompiledImplementationTypeFilter InNamespaceOf(Type first, params Type[] types);
+
+        /// <summary>
+        /// Will match all types in any of the <paramref name="namespaces"/> specified.
+        /// </summary>
+        /// <param name="first">The first namespace to include.</param>
+        /// <param name="namespaces">The namespaces to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="namespaces"/> argument is <c>null</c>.</exception>
         ICompiledImplementationTypeFilter InNamespaces(string first, params string[] namespaces);
+
+        /// <summary>
+        /// Will match all types outside of the same namespace as the type <typeparamref name="T"/>.
+        /// </summary>
         ICompiledImplementationTypeFilter NotInNamespaceOf<T>();
-        ICompiledImplementationTypeFilter NotInNamespaceOf(Type first);
+
+        /// <summary>
+        /// Will match all types outside of all of the namespaces of the <paramref name="types" /> specified.
+        /// </summary>
+        /// <param name="first">The first type in the namespaces to include.</param>
+        /// <param name="types">The types in the namespaces to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="types"/> argument is <c>null</c>.</exception>
+        ICompiledImplementationTypeFilter NotInNamespaceOf(Type first, params Type[] types);
+
+        /// <summary>
+        /// Will match all types outside of all of the <paramref name="namespaces"/> specified.
+        /// </summary>
+        /// <param name="first">The first namespace to include.</param>
+        /// <param name="namespaces">The namespaces to include.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="namespaces"/> argument is <c>null</c>.</exception>
         ICompiledImplementationTypeFilter NotInNamespaces(string first, params string[] namespaces);
-        ICompiledImplementationTypeFilter WithAttribute<T>();
-        ICompiledImplementationTypeFilter WithoutAttribute<T>();
+
+        /// <summary>
+        /// Will match all types that has an attribute of type <typeparamref name="T"/> defined.
+        /// </summary>
+        /// <typeparam name="T">The type of attribute that needs to be defined.</typeparam>
+        ICompiledImplementationTypeFilter WithAttribute<T>() where T : Attribute;
+
+        /// <summary>
+        /// Will match all types that has an attribute of <paramref name="attributeType" /> defined.
+        /// </summary>
+        /// <param name="attributeType">Type of the attribute.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="attributeType"/> argument is <c>null</c>.</exception>
+        ICompiledImplementationTypeFilter WithAttribute(Type attributeType);
+
+        /// <summary>
+        /// Will match all types that doesn't have an attribute of type <typeparamref name="T"/> defined.
+        /// </summary>
+        /// <typeparam name="T">The type of attribute that needs to be defined.</typeparam>
+        ICompiledImplementationTypeFilter WithoutAttribute<T>() where T : Attribute;
+
+        /// <summary>
+        /// Will match all types that doesn't have an attribute of <paramref name="attributeType" /> defined.
+        /// </summary>
+        /// <param name="attributeType">Type of the attribute.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="attributeType"/> argument is <c>null</c>.</exception>
+        ICompiledImplementationTypeFilter WithoutAttribute(Type attributeType);
     }
 }

--- a/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
+++ b/src/Scrutor/Static/ICompiledImplementationTypeFilter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Scrutor.Static
+{
+    public interface ICompiledImplementationTypeFilter
+    {
+        ICompiledImplementationTypeFilter AssignableTo<T>();
+        ICompiledImplementationTypeFilter AssignableTo(Type type);
+        ICompiledImplementationTypeFilter AssignableToAny(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter InExactNamespaceOf<T>();
+        ICompiledImplementationTypeFilter InExactNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter InExactNamespaces(string first, params string[] namespaces);
+        ICompiledImplementationTypeFilter InNamespaceOf<T>();
+        ICompiledImplementationTypeFilter InNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter InNamespaces(string first, params string[] namespaces);
+        ICompiledImplementationTypeFilter NotInNamespaceOf<T>();
+        ICompiledImplementationTypeFilter NotInNamespaceOf(Type first, params Type[] types);
+        ICompiledImplementationTypeFilter NotInNamespaces(string first, params string[] namespaces);
+        ICompiledImplementationTypeFilter WithAttribute<T>();
+        ICompiledImplementationTypeFilter WithoutAttribute<T>();
+    }
+}

--- a/src/Scrutor/Static/ICompiledImplementationTypeSelector.cs
+++ b/src/Scrutor/Static/ICompiledImplementationTypeSelector.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Scrutor.Static
+{
+    public interface ICompiledImplementationTypeSelector : ICompiledAssemblySelector
+    {
+        /// <summary>
+        /// Adds all public, non-abstract classes from the selected assemblies to the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+        /// </summary>
+        ICompiledServiceTypeSelector AddClasses();
+
+        /// <summary>
+        /// Adds all non-abstract classes from the selected assemblies to the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+        /// </summary>
+        /// <param name="publicOnly">Specifies whether too add public types only.</param>
+        ICompiledServiceTypeSelector AddClasses(bool publicOnly);
+
+        /// <summary>
+        /// Adds all public, non-abstract classes from the selected assemblies that
+        /// matches the requirements specified in the <paramref name="action"/>
+        /// to the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+        /// </summary>
+        /// <param name="action">The filtering action.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="action"/> argument is <c>null</c>.</exception>
+        ICompiledServiceTypeSelector AddClasses(Action<ICompiledImplementationTypeFilter> action);
+
+        /// <summary>
+        /// Adds all non-abstract classes from the selected assemblies that
+        /// matches the requirements specified in the <paramref name="action"/>
+        /// to the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+        /// </summary>
+        /// <param name="action">The filtering action.</param>
+        /// <exception cref="ArgumentNullException">If the <paramref name="action"/> argument is <c>null</c>.</exception>
+        /// <param name="publicOnly">Specifies whether too add public types only.</param>
+        ICompiledServiceTypeSelector AddClasses(Action<ICompiledImplementationTypeFilter> action, bool publicOnly);
+    }
+}

--- a/src/Scrutor/Static/ICompiledLifetimeSelector.cs
+++ b/src/Scrutor/Static/ICompiledLifetimeSelector.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scrutor.Static
+{
+    public interface ICompiledLifetimeSelector : ICompiledServiceTypeSelector
+    {
+        /// <summary>
+        /// Registers each matching concrete type with <see cref="ServiceLifetime.Singleton"/> lifetime.
+        /// </summary>
+        void WithSingletonLifetime();
+
+        /// <summary>
+        /// Registers each matching concrete type with <see cref="ServiceLifetime.Scoped"/> lifetime.
+        /// </summary>
+        void WithScopedLifetime();
+
+        /// <summary>
+        /// Registers each matching concrete type with <see cref="ServiceLifetime.Transient"/> lifetime.
+        /// </summary>
+        void WithTransientLifetime();
+
+        /// <summary>
+        /// Registers each matching concrete type with the specified <paramref name="lifetime"/>.
+        /// </summary>
+        void WithLifetime(ServiceLifetime lifetime);
+    }
+}

--- a/src/Scrutor/Static/ICompiledServiceTypeSelector.cs
+++ b/src/Scrutor/Static/ICompiledServiceTypeSelector.cs
@@ -1,4 +1,4 @@
-
+using Scrutor;
 
 namespace Scrutor.Static
 {
@@ -29,5 +29,10 @@ namespace Scrutor.Static
         /// Registers the type with the first found matching interface name.  (e.g. ClassName is matched to IClassName)
         /// </summary>
         ICompiledLifetimeSelector AsMatchingInterface();
+
+        /// <summary>
+        /// Registers each matching concrete type according to their ServiceDescriptorAttribute.
+        /// </summary>
+        ICompiledLifetimeSelector UsingAttributes();
     }
 }

--- a/src/Scrutor/Static/ICompiledServiceTypeSelector.cs
+++ b/src/Scrutor/Static/ICompiledServiceTypeSelector.cs
@@ -1,0 +1,33 @@
+
+
+namespace Scrutor.Static
+{
+    public interface ICompiledServiceTypeSelector
+    {
+        /// <summary>
+        /// Registers each matching concrete type as itself.
+        /// </summary>
+        ICompiledLifetimeSelector AsSelf();
+
+        /// <summary>
+        /// Registers each matching concrete type as <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to register as.</typeparam>
+        ICompiledLifetimeSelector As<T>();
+
+        /// <summary>
+        /// Registers each matching concrete type as all of its implemented interfaces.
+        /// </summary>
+        ICompiledLifetimeSelector AsImplementedInterfaces();
+
+        /// <summary>
+        /// Registers each matching concrete type as all of its implemented interfaces, by returning an instance of the main type
+        /// </summary>
+        ICompiledLifetimeSelector AsSelfWithInterfaces();
+
+        /// <summary>
+        /// Registers the type with the first found matching interface name.  (e.g. ClassName is matched to IClassName)
+        /// </summary>
+        ICompiledLifetimeSelector AsMatchingInterface();
+    }
+}

--- a/test/Scrutor.Tests/CollectibleTestAssemblyLoadContext.cs
+++ b/test/Scrutor.Tests/CollectibleTestAssemblyLoadContext.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Scrutor.Tests
+{
+    public class CollectibleTestAssemblyLoadContext : AssemblyLoadContext, IDisposable
+    {
+        public CollectibleTestAssemblyLoadContext() : base(
+#if NETCOREAPP3_1
+            isCollectible: true
+#endif
+
+            ) { }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+
+        public void Dispose()
+        {
+#if NETCOREAPP3_1
+            Unload();
+#endif
+        }
+    }
+}

--- a/test/Scrutor.Tests/GenerationHelpers.cs
+++ b/test/Scrutor.Tests/GenerationHelpers.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Scrutor.Tests
+{
+    public static class GenerationHelpers
+    {
+        static GenerationHelpers()
+        {
+            // this "core assemblies hack" is from https://stackoverflow.com/a/47196516/4418060
+            var coreAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            var coreAssemblyNames = new[]
+            {
+                "mscorlib.dll",
+                "netstandard.dll",
+                "System.dll",
+                "System.Core.dll",
+#if NETCOREAPP
+                "System.Private.CoreLib.dll",
+                "System.ComponentModel.dll",
+#endif
+                "System.Runtime.dll",
+                "System.Linq.dll",
+            };
+            var coreMetaReferences =
+                coreAssemblyNames.Select(x => MetadataReference.CreateFromFile(Path.Combine(coreAssemblyPath, x)));
+            MetadataReferences = coreMetaReferences.ToImmutableArray();
+        }
+
+        internal const string CrLf = "\r\n";
+        internal const string Lf = "\n";
+        internal const string DefaultFilePathPrefix = "Test";
+        internal const string CSharpDefaultFileExt = "cs";
+        internal const string TestProjectName = "TestProject";
+
+        // internal static readonly string NormalizedPreamble = NormalizeToLf(Preamble.GeneratedByATool + Lf);
+
+        internal static readonly ImmutableArray<PortableExecutableReference> MetadataReferences;
+
+        public static async Task AssertGeneratedAsExpected<T>(IEnumerable<Assembly> metadataReferences, string source, string expected, string? pathHint = null)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Where(z => pathHint == null || z.FilePath.Contains(pathHint, StringComparison.OrdinalIgnoreCase))
+                .Select(z => NormalizeToLf(z.GetText().ToString()));
+            // and append preamble to the expected
+            var expectedText = NormalizeToLf(expected).Trim();
+            Assert.Equal(generatedText.Last(), expectedText);
+        }
+
+        public static async Task AssertGeneratedAsExpected<T>(IEnumerable<Assembly> metadataReferences, IEnumerable<string> sources, IEnumerable<string> expected, string? pathHint = null)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(sources, metadataReferences).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Where(z => pathHint == null || z.FilePath.Contains(pathHint, StringComparison.OrdinalIgnoreCase))
+                .Select(z => NormalizeToLf(z.GetText().ToString())).ToArray();
+            // and append preamble to the expected
+            var expectedText = expected.Select(z => NormalizeToLf(z).Trim()).ToArray();
+
+            Assert.Equal(generatedText.Length, expectedText.Length);
+            foreach (var (generated, expectedTxt) in generatedText.Zip(expectedText, (generated, expected) => (generated, expected)))
+            {
+                Assert.Equal(generated, expectedTxt);
+            }
+        }
+
+        public static async Task AssertGeneratedAsExpected<T>(string source, string expected, string? pathHint = null)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>()).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Where(z => pathHint == null || z.FilePath.Contains(pathHint, StringComparison.OrdinalIgnoreCase))
+                .Select(z => NormalizeToLf(z.GetText().ToString()));
+            // and append preamble to the expected
+            var expectedText = NormalizeToLf(expected).Trim();
+            Assert.Equal(generatedText.Last(), expectedText);
+        }
+
+        public static async Task<string> Generate<T>(IEnumerable<Assembly> metadataReferences, string source, string? pathHint = null)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Where(z => pathHint == null || z.FilePath.Contains(pathHint, StringComparison.OrdinalIgnoreCase))
+                .Select(z => NormalizeToLf(z.GetText().ToString()));
+            // and append preamble to the expected
+            return generatedText.Last();
+        }
+
+        public static async Task<string[]> Generate<T>(IEnumerable<Assembly> metadataReferences, IEnumerable<string> sources)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(sources, metadataReferences).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Select(z => NormalizeToLf(z.GetText().ToString()));
+            // and append preamble to the expected
+            return generatedText.ToArray();
+        }
+
+        public static async Task<string> Generate<T>(string source)
+            where T : ISourceGenerator, new()
+        {
+            var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>()).ConfigureAwait(false);
+            // normalize line endings to just LF
+            var generatedText = generatedTree
+                .Select(z => NormalizeToLf(z.GetText().ToString()));
+            // and append preamble to the expected
+            return generatedText.Last();
+        }
+
+        public static string NormalizeToLf(string input) => input.Replace(CrLf, Lf);
+
+        public static async Task<IEnumerable<SyntaxTree>> GenerateAsync<T>(IEnumerable<string> sources, IEnumerable<Assembly> metadataReferences)
+            where T : ISourceGenerator, new()
+        {
+            var references = metadataReferences
+                .Concat(
+                    new[]
+                    {
+                        typeof(IServiceCollection).Assembly,
+                        typeof(ServiceCollection).Assembly,
+                        typeof(IFluentInterface).Assembly,
+                    }
+                )
+                .Distinct()
+                .Select(x => MetadataReference.CreateFromFile(x.Location))
+                .ToArray();
+            var project = CreateProject(references, sources.ToArray());
+
+            var compilation = (CSharpCompilation?)await project.GetCompilationAsync().ConfigureAwait(false);
+            if (compilation is null)
+            {
+                throw new InvalidOperationException("Could not compile the sources");
+            }
+
+            var startingSyntaxTress = compilation.SyntaxTrees.Length;
+
+            // var diagnostics = compilation.GetDiagnostics();
+            // Assert.Empty(diagnostics.Where(x => x.Severity > DiagnosticSeverity.Warning));
+
+            ISourceGenerator generator = new T();
+
+            var driver = new CSharpGeneratorDriver(compilation.SyntaxTrees[0].Options, ImmutableArray.Create(generator), default, ImmutableArray<AdditionalText>.Empty);
+
+            driver.RunFullGeneration(compilation, out var outputCompilation, out var innerDiagnostics);
+
+            var diagnostics = outputCompilation.GetDiagnostics();
+            Assert.Empty(diagnostics.Where(x => x.Severity > DiagnosticSeverity.Warning));
+            // Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
+
+            // the syntax tree added by the generator will be the last one in the compilation
+            return outputCompilation.SyntaxTrees.TakeLast(outputCompilation.SyntaxTrees.Count() - startingSyntaxTress);
+        }
+
+        public static async Task<CSharpCompilation> CreateProject<T>(IEnumerable<Assembly> metadataReferences, params string[] sources)
+            where T : ISourceGenerator, new()
+        {
+            var references = metadataReferences
+                .Concat(
+                    new[]
+                    {
+                        typeof(IServiceCollection).Assembly,
+                        typeof(ServiceCollection).Assembly,
+                        typeof(IFluentInterface).Assembly,
+                    }
+                )
+                .Distinct()
+                .Select(x => MetadataReference.CreateFromFile(x.Location))
+                .ToArray();
+
+            var project = CreateProject(references, sources);
+
+
+            var compilation = (CSharpCompilation?)await project.GetCompilationAsync().ConfigureAwait(false);
+            if (compilation is null)
+            {
+                throw new InvalidOperationException("Could not compile the sources");
+            }
+
+            // var diagnostics = compilation.GetDiagnostics();
+            // Assert.Empty(diagnostics.Where(x => x.Severity > DiagnosticSeverity.Warning));
+
+            ISourceGenerator generator = new T();
+
+            var driver = new CSharpGeneratorDriver(compilation.SyntaxTrees[0].Options, ImmutableArray.Create(generator), default, ImmutableArray<AdditionalText>.Empty);
+
+            driver.RunFullGeneration(compilation, out var outputCompilation, out var innerDiagnostics);
+
+            var diagnostics = outputCompilation.GetDiagnostics();
+            // Assert.Empty(diagnostics.Where(x => x.Severity > DiagnosticSeverity.Warning));
+
+            return (outputCompilation as CSharpCompilation)!;
+        }
+
+        public static Project CreateProject(IEnumerable<MetadataReference> metadataReferences, params string[] sources)
+        {
+            var projectId = ProjectId.CreateNewId(TestProjectName);
+            var solution = new AdhocWorkspace()
+                .CurrentSolution
+                .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                .WithProjectCompilationOptions(
+                    projectId,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                )
+                .WithProjectParseOptions(
+                    projectId,
+                    new CSharpParseOptions(preprocessorSymbols: new[] { "SOMETHING_ACTIVE" })
+                )
+                .AddMetadataReferences(projectId, MetadataReferences.Concat(metadataReferences ?? Array.Empty<MetadataReference>()));
+
+            var count = 0;
+            foreach (var source in sources)
+            {
+                var newFileName = DefaultFilePathPrefix + count + "." + CSharpDefaultFileExt;
+                var documentId = DocumentId.CreateNewId(projectId, newFileName);
+                solution = solution.AddDocument(documentId, newFileName, SourceText.From(source));
+                count++;
+            }
+
+            var project = solution.GetProject(projectId);
+            if (project is null)
+            {
+                throw new InvalidOperationException($"The ad hoc workspace does not contain a project with the id {projectId.Id}");
+            }
+
+            return project;
+        }
+    }
+}

--- a/test/Scrutor.Tests/GenerationHelpers.cs
+++ b/test/Scrutor.Tests/GenerationHelpers.cs
@@ -320,10 +320,10 @@ namespace Scrutor.Tests
             return context.LoadFromStream(assemblyStream);
         }
 
-        public static MetadataReference CreateMetadataReference(this CSharpCompilation compilation, string? outputName = null)
+        public static MetadataReference CreateMetadataReference(this CSharpCompilation compilation)
         {
             using var stream = new MemoryStream();
-            var emitResult = compilation.Emit(stream, options: new EmitOptions(outputNameOverride: outputName));
+            var emitResult = compilation.Emit(stream, options: new EmitOptions(outputNameOverride: compilation.AssemblyName));
             if (!emitResult.Success)
             {
                 Assert.Empty(emitResult.Diagnostics);

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Scrutor\Scrutor.csproj" />
+    <ProjectReference Include="..\..\src\Scrutor.Analyzers\Scrutor.Analyzers.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/test/Scrutor.Tests/StaticScanningTests.cs
+++ b/test/Scrutor.Tests/StaticScanningTests.cs
@@ -1,0 +1,480 @@
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor.Tests;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Emit;
+using Scrutor.Analyzers;
+using Xunit;
+using Xunit.Abstractions;
+using static Scrutor.Tests.GenerationHelpers;
+
+namespace Scrutor.Tests
+{
+
+    public class StaticScanningTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        public StaticScanningTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Theory]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Transient)]
+        public async Task Should_Have_Correct_Lifetime(ServiceLifetime serviceLifetime)
+        {
+            var source = $@"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService
+{{
+
+}}
+
+public class Service : IService
+{{
+
+}}
+
+public interface IServiceB
+{{
+
+}}
+
+public class ServiceB : IServiceB
+{{
+
+}}
+
+public static class Program {{
+    static ServiceCollection Services = new ServiceCollection();
+    static void Main()
+    {{
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IService>(), false)
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .With{
+                    serviceLifetime
+                }Lifetime()
+        );
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IServiceB>(), false)
+            .AsSelf()
+            .AsMatchingInterface()
+            .WithLifetime(ServiceLifetime.{
+                    serviceLifetime
+                })
+        );
+    }}
+}}
+";
+
+            var expected = $@"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{{
+    internal static class PopulateExtensions
+    {{
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, string filePath, string memberName, int lineNumber)
+        {{
+            switch (lineNumber)
+            {{
+                case 30:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.{
+                    serviceLifetime
+                }));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService(typeof(Service)), ServiceLifetime.{
+                    serviceLifetime
+                }));
+                    break;
+                case 37:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.{
+                    serviceLifetime
+                }));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService(typeof(ServiceB)), ServiceLifetime.{
+                    serviceLifetime
+                }));
+                    break;
+            }}
+
+            return services;
+        }}
+    }}
+}}
+";
+
+
+            await AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                new[] { typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                source,
+                expected,
+                "Scrutor.Static.Populate.cs"
+            ).ConfigureAwait(false);
+        }
+
+
+        [Theory]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Transient)]
+        public async Task Should_Have_Correct_Lifetime_Real_Code(ServiceLifetime serviceLifetime)
+        {
+            var source = $@"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService
+{{
+
+}}
+
+public class Service : IService
+{{
+
+}}
+
+public interface IServiceB
+{{
+
+}}
+
+public class ServiceB : IServiceB
+{{
+
+}}
+
+public static class Program {{
+    static ServiceCollection Services = new ServiceCollection();
+    static void Main() {{ }}
+    static void LoadServices()
+    {{
+	    Services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IService>())
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .With{
+                    serviceLifetime
+                }Lifetime()
+        );
+	    Services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IServiceB>(), false)
+            .AsSelf()
+            .AsMatchingInterface()
+            .WithLifetime(ServiceLifetime.{
+                    serviceLifetime
+                })
+        );
+    }}
+}}
+";
+            var compilation = await CreateProject<StaticScrutorGenerator>(
+                new[] { typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                source
+            ).ConfigureAwait(false);
+
+            using var context = new CollectibleTestAssemblyLoadContext();
+
+            var extensionTree = compilation.SyntaxTrees.FirstOrDefault(z => z.GetText().ToString().Contains("switch"));
+            _testOutputHelper.WriteLine(extensionTree.GetText().ToString());
+
+            byte[] data;
+            {
+                using var stream = new MemoryStream();
+                var emitResult = compilation!.Emit(stream, options: new EmitOptions());
+                if (!emitResult.Success)
+                {
+                    Assert.Empty(emitResult.Diagnostics);
+                }
+
+                data = stream.ToArray();
+            }
+
+            using var assemblyStream = new MemoryStream(data);
+            var assembly = context.LoadFromStream(assemblyStream);
+
+            var extension = assembly.GetTypes().FirstOrDefault(z => z.IsClass && z.Name == "Program");
+            Assert.NotNull(extension);
+
+            var method = extension.GetMethod("LoadServices", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var servicesfield = extension.GetField("Services", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(servicesfield);
+
+            var services = servicesfield!.GetValue(null) as IServiceCollection;
+            Assert.NotNull(services);
+
+            method.Invoke(null, new object[] { });
+
+            Assert.Equal(4, services.Count());
+            Assert.Equal(2, services.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(2, services.Count(z => z.ImplementationType is not null));
+        }
+
+        [Fact]
+        public async Task Should_Split_Correctly_Given_Same_Line_Number()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService
+{
+
+}
+
+public class Service : IService
+{
+
+}
+
+public interface IServiceB
+{
+
+}
+
+public class ServiceB : IServiceB
+{
+
+}
+";
+
+            var source1 = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program {
+    static ServiceCollection Services = new ServiceCollection();
+    static void Main() {}
+    static void Method()
+    {
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IService>(), false)
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithSingletonLifetime()
+        );
+    }
+}
+";
+
+            var source2 = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program2 {
+    static ServiceCollection Services = new ServiceCollection();
+
+    static void Method()
+    {
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IServiceB>(), false)
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+    }
+}
+";
+
+            var expected = @"
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, string filePath, string memberName, int lineNumber)
+        {
+            switch (lineNumber)
+            {
+                case 11:
+                    switch (filePath)
+                    {
+                        case ""Test1.cs"":
+                            strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.Singleton));
+                            strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService(typeof(Service)), ServiceLifetime.Singleton));
+                            break;
+                        case ""Test2.cs"":
+                            strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.Scoped));
+                            strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService(typeof(ServiceB)), ServiceLifetime.Scoped));
+                            break;
+                    }
+
+                    break;
+            }
+
+            return services;
+        }
+    }
+}
+";
+
+
+            await AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                new[] { typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                new[] { source, source1, source2 },
+                new[] { expected },
+                "Scrutor.Static.Populate.cs"
+            ).ConfigureAwait(false);
+        }
+
+
+        [Fact]
+        public async Task Should_Split_Correctly_Given_Same_Line_Number_Run()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService
+{
+
+}
+
+public class Service : IService
+{
+
+}
+
+public interface IServiceB
+{
+
+}
+
+public class ServiceB : IServiceB
+{
+
+}
+";
+
+            var source1 = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program {
+    static ServiceCollection Services = new ServiceCollection();
+    static void Main() {}
+    static void Method()
+    {
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IService>(), false)
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithSingletonLifetime()
+        );
+    }
+}
+";
+
+            var source2 = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program2 {
+    static ServiceCollection Services = new ServiceCollection();
+
+    static void Method()
+    {
+	    Services.ScanStatic(z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo<IServiceB>(), false)
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+    }
+}
+";
+            var compilation = await CreateProject<StaticScrutorGenerator>(
+                new[] { typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                source, source1, source2
+            ).ConfigureAwait(false);
+
+            using var context = new CollectibleTestAssemblyLoadContext();
+
+            var extensionTree = compilation.SyntaxTrees.FirstOrDefault(z => z.GetText().ToString().Contains("switch"));
+
+            byte[] data;
+            {
+                using var stream = new MemoryStream();
+                var emitResult = compilation!.Emit(stream, options: new EmitOptions());
+                if (!emitResult.Success)
+                {
+                    Assert.Empty(emitResult.Diagnostics);
+                }
+
+                data = stream.ToArray();
+            }
+
+            using var assemblyStream = new MemoryStream(data);
+            var assembly = context.LoadFromStream(assemblyStream);
+
+            var program1 = assembly.GetTypes().FirstOrDefault(z => z.IsClass && z.Name == "Program");
+            Assert.NotNull(program1);
+
+            var method1 = program1.GetMethod("Method", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method1);
+
+            var servicesField1 = program1.GetField("Services", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(servicesField1);
+
+            var services1 = servicesField1!.GetValue(null) as IServiceCollection;
+            Assert.NotNull(services1);
+
+            var program2 = assembly.GetTypes().FirstOrDefault(z => z.IsClass && z.Name == "Program2");
+            Assert.NotNull(program2);
+
+            var method2 = program2.GetMethod("Method", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method2);
+
+            var servicesField2 = program2.GetField("Services", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(servicesField2);
+
+            var services2 = servicesField2!.GetValue(null) as IServiceCollection;
+            Assert.NotNull(services2);
+
+            method1.Invoke(null, new object[] {  });
+            method2.Invoke(null, new object[] {  });
+
+            Assert.Equal(2, services1.Count());
+            Assert.Equal(1, services1.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(1, services1.Count(z => z.ImplementationType is not null));
+            Assert.Equal(2, services1.Count(z => z.Lifetime == ServiceLifetime.Singleton));
+
+            Assert.Equal(2, services2.Count());
+            Assert.Equal(1, services2.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(1, services2.Count(z => z.ImplementationType is not null));
+            Assert.Equal(2, services2.Count(z => z.Lifetime == ServiceLifetime.Scoped));
+        }
+    }
+}

--- a/test/Scrutor.Tests/StaticScanningTests.cs
+++ b/test/Scrutor.Tests/StaticScanningTests.cs
@@ -13,10 +13,10 @@ using static Scrutor.Tests.GenerationHelpers;
 
 namespace Scrutor.Tests
 {
-
     public class StaticScanningTests
     {
         private readonly ITestOutputHelper _testOutputHelper;
+
         public StaticScanningTests(ITestOutputHelper testOutputHelper)
         {
             _testOutputHelper = testOutputHelper;
@@ -62,18 +62,14 @@ public static class Program {{
 			.AddClasses(x => x.AssignableTo<IService>(), false)
             .AsSelf()
             .AsImplementedInterfaces()
-            .With{
-                    serviceLifetime
-                }Lifetime()
+            .With{serviceLifetime}Lifetime()
         );
 	    Services.ScanStatic(z => z
 			.FromAssemblies()
 			.AddClasses(x => x.AssignableTo<IServiceB>(), false)
             .AsSelf()
             .AsMatchingInterface()
-            .WithLifetime(ServiceLifetime.{
-                    serviceLifetime
-                })
+            .WithLifetime(ServiceLifetime.{serviceLifetime})
         );
     }}
 }}
@@ -93,20 +89,12 @@ namespace Scrutor.Static
             switch (lineNumber)
             {{
                 case 30:
-                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.{
-                    serviceLifetime
-                }));
-                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService(typeof(Service)), ServiceLifetime.{
-                    serviceLifetime
-                }));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.{serviceLifetime}));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService(typeof(Service)), ServiceLifetime.{serviceLifetime}));
                     break;
                 case 37:
-                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.{
-                    serviceLifetime
-                }));
-                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService(typeof(ServiceB)), ServiceLifetime.{
-                    serviceLifetime
-                }));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.{serviceLifetime}));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService(typeof(ServiceB)), ServiceLifetime.{serviceLifetime}));
                     break;
             }}
 
@@ -118,7 +106,7 @@ namespace Scrutor.Static
 
 
             await AssertGeneratedAsExpected<StaticScrutorGenerator>(
-                new[] { typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                new[] {typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly},
                 source,
                 expected,
                 "Scrutor.Static.Populate.cs"
@@ -186,7 +174,7 @@ public static class Program {{
 }}
 ";
             var compilation = await CreateProject<StaticScrutorGenerator>(
-                new[] { typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                new[] {typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly},
                 source
             ).ConfigureAwait(false);
 
@@ -337,9 +325,9 @@ namespace Scrutor.Static
 
 
             await AssertGeneratedAsExpected<StaticScrutorGenerator>(
-                new[] { typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
-                new[] { source, source1, source2 },
-                new[] { expected },
+                new[] {typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly},
+                new[] {source, source1, source2},
+                new[] {expected},
                 "Scrutor.Static.Populate.cs"
             ).ConfigureAwait(false);
         }
@@ -416,7 +404,7 @@ public static class Program2 {
 }
 ";
             var compilation = await CreateProject<StaticScrutorGenerator>(
-                new[] { typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly },
+                new[] {typeof(IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly},
                 source, source1, source2
             ).ConfigureAwait(false);
 
@@ -463,8 +451,8 @@ public static class Program2 {
             var services2 = servicesField2!.GetValue(null) as IServiceCollection;
             Assert.NotNull(services2);
 
-            method1.Invoke(null, new object[] {  });
-            method2.Invoke(null, new object[] {  });
+            method1.Invoke(null, new object[] { });
+            method2.Invoke(null, new object[] { });
 
             Assert.Equal(2, services1.Count());
             Assert.Equal(1, services1.Count(z => z.ImplementationFactory is not null));

--- a/test/Scrutor.Tests/StaticScanningTests.cs
+++ b/test/Scrutor.Tests/StaticScanningTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using Scrutor.Analyzers;
+using Scrutor.Analyzers.Internals;
 using Xunit;
 using Xunit.Abstractions;
 using static Scrutor.Tests.GenerationHelpers;
@@ -235,8 +236,7 @@ public static class Program {
         z => z
 			.FromAssemblies()
 			.AddClasses(x => x.AssignableTo(typeof(IService<>)))
-            .AsSelf()
-            .AsImplementedInterfaces()
+            .AsSelfWithInterfaces()
             .WithScopedLifetime()
         );
         return services;
@@ -582,6 +582,157 @@ namespace Scrutor.Static
             Assert.Equal(1, services.Count());
             Assert.Equal(1, services.Count(z => z.ImplementationType is not null));
             Assert.Equal(1, services.Count(z => z.Lifetime == ServiceLifetime.Singleton));
+        }
+
+
+        [Fact]
+        public void Should_Ignore_Abstract_Classes()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public class Service : IService { }
+public abstract class ServiceB : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo(typeof(IService)))
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+        return services;
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, AssemblyLoadContext context, string filePath, string memberName, int lineNumber)
+        {
+            switch (lineNumber)
+            {
+                case 15:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService<Service>(), ServiceLifetime.Scoped));
+                    break;
+            }
+
+            return services;
+        }
+    }
+}
+";
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                    source,
+                    expected,
+                    "Scrutor.Static.Populate.cs"
+                );
+
+            generator.AssertCompilationWasSuccessful();
+            generator.AssertGenerationWasSuccessful();
+
+            var services = StaticHelper.ExecuteStaticServiceCollectionMethod(generator.Emit(), "Program", "LoadServices");
+            Assert.Equal(2, services.Count());
+            Assert.Equal(1, services.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(1, services.Count(z => z.ImplementationType is not null));
+            Assert.Equal(2, services.Count(z => z.Lifetime == ServiceLifetime.Scoped));
+        }
+
+
+        [Fact]
+        public void Should_Using_Support_As_Type()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public class Service : IService { }
+public abstract class ServiceB : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo(typeof(IService)))
+            .As<IService>()
+            .WithScopedLifetime()
+        );
+        return services;
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, AssemblyLoadContext context, string filePath, string memberName, int lineNumber)
+        {
+            switch (lineNumber)
+            {
+                case 15:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), typeof(Service), ServiceLifetime.Scoped));
+                    break;
+            }
+
+            return services;
+        }
+    }
+}
+";
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                    source,
+                    expected,
+                    "Scrutor.Static.Populate.cs"
+                );
+
+            generator.AssertCompilationWasSuccessful();
+            generator.AssertGenerationWasSuccessful();
+
+            var services = StaticHelper.ExecuteStaticServiceCollectionMethod(generator.Emit(), "Program", "LoadServices");
+            Assert.Single(services);
+            Assert.Equal(1, services.Count(z => z.ImplementationType is not null));
+            Assert.Equal(1, services.Count(z => z.Lifetime == ServiceLifetime.Scoped));
         }
 
 
@@ -1109,6 +1260,370 @@ namespace Scrutor.Static
             Assert.Equal(1, services2.Count(z => z.ImplementationFactory is not null));
             Assert.Equal(1, services2.Count(z => z.ImplementationType is not null));
             Assert.Equal(2, services2.Count(z => z.Lifetime == ServiceLifetime.Scoped));
+        }
+
+        [Fact]
+        public void Should_Filter_AssignableTo()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public interface IServiceB { }
+public class Service : IService, IServiceB { }
+public class ServiceA : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableTo(typeof(IService)).AssignableTo<IServiceB>())
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+        return services;
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, AssemblyLoadContext context, string filePath, string memberName, int lineNumber)
+        {
+            switch (lineNumber)
+            {
+                case 16:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService<Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService<Service>(), ServiceLifetime.Scoped));
+                    break;
+            }
+
+            return services;
+        }
+    }
+}
+";
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                    source,
+                    expected,
+                    "Scrutor.Static.Populate.cs"
+                );
+
+            generator.AssertCompilationWasSuccessful();
+            generator.AssertGenerationWasSuccessful();
+
+            var services = StaticHelper.ExecuteStaticServiceCollectionMethod(generator.Emit(), "Program", "LoadServices");
+            Assert.Equal(3, services.Count());
+            Assert.Equal(2, services.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(1, services.Count(z => z.ImplementationType is not null));
+            Assert.Equal(3, services.Count(z => z.Lifetime == ServiceLifetime.Scoped));
+        }
+
+        [Fact]
+        public void Should_Filter_AssignableToAny()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public interface IServiceB { }
+public class Service : IService, IServiceB { }
+public class ServiceA : IService { }
+public class ServiceB : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.AssignableToAny(typeof(IService), typeof(IServiceB)))
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+        return services;
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{
+    internal static class PopulateExtensions
+    {
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, AssemblyLoadContext context, string filePath, string memberName, int lineNumber)
+        {
+            switch (lineNumber)
+            {
+                case 17:
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService<Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService<Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceA), typeof(ServiceA), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService<ServiceA>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService<ServiceB>(), ServiceLifetime.Scoped));
+                    break;
+            }
+
+            return services;
+        }
+    }
+}
+";
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                    source,
+                    expected,
+                    "Scrutor.Static.Populate.cs"
+                );
+
+            generator.AssertCompilationWasSuccessful();
+            generator.AssertGenerationWasSuccessful();
+
+            var services = StaticHelper.ExecuteStaticServiceCollectionMethod(generator.Emit(), "Program", "LoadServices");
+            Assert.Equal(7, services.Count());
+            Assert.Equal(4, services.Count(z => z.ImplementationFactory is not null));
+            Assert.Equal(3, services.Count(z => z.ImplementationType is not null));
+            Assert.Equal(7, services.Count(z => z.Lifetime == ServiceLifetime.Scoped));
+        }
+
+        [Theory]
+        [InlineData(NamespaceFilter.Exact, "TestProject.A", 5, false, false)]
+        [InlineData(NamespaceFilter.Exact, "TestProject.A.IService", 5, true, false)]
+        [InlineData(NamespaceFilter.Exact, "TestProject.A.IService", 5, true, true)]
+        [InlineData(NamespaceFilter.In, "TestProject.A", 7, false, false)]
+        [InlineData(NamespaceFilter.In, "TestProject.A.IService", 7, true, false)]
+        [InlineData(NamespaceFilter.In, "TestProject.A.IService", 7, true, true)]
+        [InlineData(NamespaceFilter.NotIn, "TestProject.A.C", 7, false, false)]
+        [InlineData(NamespaceFilter.NotIn, "TestProject.A.C.ServiceC", 7, true, false)]
+        [InlineData(NamespaceFilter.NotIn, "TestProject.A.C.ServiceC", 7, true, true)]
+        public void Should_Filter_Namespaces(NamespaceFilter filter, string namespaceFilterValue, int count, bool usingClass, bool usingTypeof)
+        {
+            var source = $@"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TestProject.A
+{{
+    public interface IService {{ }}
+    public class Service : IService, TestProject.B.IServiceB {{ }}
+    public class ServiceA : IService {{ }}
+}}
+
+namespace TestProject.A.C
+{{
+    public class ServiceC : IService {{ }}
+}}
+
+namespace TestProject.B
+{{
+    public interface IServiceB {{ }}
+    public class ServiceB : TestProject.A.IService {{ }}
+}}
+
+public static class Program {{
+    static void Main() {{ }}
+    static IServiceCollection LoadServices()
+    {{
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => z
+			.FromAssemblies()
+			.AddClasses(x => x.{
+                (usingClass, usingTypeof, filter) switch {
+                    (false, false, NamespaceFilter.Exact) => $"InExactNamespaces(\"{namespaceFilterValue}\")",
+                    (false, false, NamespaceFilter.In) => $"InNamespaces(\"{namespaceFilterValue}\")",
+                    (false, false, NamespaceFilter.NotIn) => $"InNamespaces(\"TestProject\").NotInNamespaces(\"{namespaceFilterValue}\")",
+                    (true, false, NamespaceFilter.Exact) => $"InExactNamespaceOf(typeof({namespaceFilterValue}))",
+                    (true, false, NamespaceFilter.In) => $"InNamespaceOf(typeof({namespaceFilterValue}))",
+                    (true, false, NamespaceFilter.NotIn) => $"InNamespaces(\"TestProject\").NotInNamespaceOf(typeof({namespaceFilterValue}))",
+                    (true, true, NamespaceFilter.Exact) => $"InExactNamespaceOf<{namespaceFilterValue}>()",
+                    (true, true, NamespaceFilter.In) => $"InNamespaceOf<{namespaceFilterValue}>()",
+                    (true, true, NamespaceFilter.NotIn) => $"InNamespaces(\"TestProject\").NotInNamespaceOf<{namespaceFilterValue}>()",
+                    _ => "ERROR"}})
+            .AsSelf()
+            .AsImplementedInterfaces()
+            .WithScopedLifetime()
+        );
+        return services;
+    }}
+}}
+";
+
+            var expected = $@"
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Scrutor.Static
+{{
+    internal static class PopulateExtensions
+    {{
+        public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, AssemblyLoadContext context, string filePath, string memberName, int lineNumber)
+        {{
+            switch (lineNumber)
+            {{
+                case 29:
+                    {
+                filter switch {
+                    NamespaceFilter.Exact => @"strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.Service), typeof(TestProject.A.Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.B.IServiceB), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.ServiceA), typeof(TestProject.A.ServiceA), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.ServiceA>(), ServiceLifetime.Scoped));",
+                    NamespaceFilter.In => @"strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.Service), typeof(TestProject.A.Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.B.IServiceB), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.ServiceA), typeof(TestProject.A.ServiceA), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.ServiceA>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.C.ServiceC), typeof(TestProject.A.C.ServiceC), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.C.ServiceC>(), ServiceLifetime.Scoped));",
+                    NamespaceFilter.NotIn => @"strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.Service), typeof(TestProject.A.Service), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.B.IServiceB), _ => _.GetRequiredService<TestProject.A.Service>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.ServiceA), typeof(TestProject.A.ServiceA), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.A.ServiceA>(), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.B.ServiceB), typeof(TestProject.B.ServiceB), ServiceLifetime.Scoped));
+                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(TestProject.A.IService), _ => _.GetRequiredService<TestProject.B.ServiceB>(), ServiceLifetime.Scoped));"
+                    }}
+                    break;
+            }}
+
+            return services;
+        }}
+    }}
+}}
+";
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .Generate<StaticScrutorGenerator>(source);
+                // .AssertGeneratedAsExpected<StaticScrutorGenerator>(
+                //     source,
+                //     expected,
+                //     "Scrutor.Static.Populate.cs"
+                // );
+
+            generator.AssertGenerationWasSuccessful();
+
+            var services = StaticHelper.ExecuteStaticServiceCollectionMethod(generator.Emit(), "Program", "LoadServices");
+            Assert.Equal(count, services.Count());
+        }
+
+        [Fact]
+        public void Should_Report_Diagnostic_When_Not_Using_Expressions()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public class Service : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var services = new ServiceCollection();
+	    services.ScanStatic(
+        z => { 
+               z.FromAssemblies()
+			    .AddClasses(x => x.AssignableTo(typeof(IService)))
+                .AsSelf()
+                .AsImplementedInterfaces()
+                .WithScopedLifetime();
+        });
+        return services;
+    }
+}
+";
+
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .Generate<StaticScrutorGenerator>(source);
+
+            Assert.NotEmpty(generator.GeneratorDiagnostics);
+            Assert.Contains(generator.GeneratorDiagnostics, z => z.Id == "SCTR0001");
+        }
+
+        [Fact]
+        public void Should_Report_Diagnostic_Not_Give_A_Compiled_Type()
+        {
+            var source = @"
+using Scrutor;
+using Scrutor.Static;
+using Microsoft.Extensions.DependencyInjection;
+
+public interface IService { }
+public class Service : IService { }
+
+public static class Program {
+    static void Main() { }
+    static IServiceCollection LoadServices()
+    {
+        var type = typeof(IService);
+        var services = new ServiceCollection();
+	    services.ScanStatic(z => z.FromAssemblies()
+			  .AddClasses(x => x.AssignableTo(type))
+              .AsSelf()
+              .AsImplementedInterfaces()
+              .WithScopedLifetime());
+        return services;
+    }
+}
+";
+
+            using var context = new CollectibleTestAssemblyLoadContext();
+            using var generator = new GeneratorTester(context)
+                .Output(_testOutputHelper);
+            generator.AddReferences(typeof(Scrutor.IFluentInterface).Assembly, typeof(ServiceCollection).Assembly, typeof(IServiceCollection).Assembly)
+                .Generate<StaticScrutorGenerator>(source);
+
+            Assert.NotEmpty(generator.GeneratorDiagnostics);
+            Assert.Contains(generator.GeneratorDiagnostics, z => z.Id == "SCTR0002");
         }
 
         static class StaticHelper


### PR DESCRIPTION
This is just an initial commit, I'm sure there are something things that could be done differently and better.

Basically source generation under the covers emits an extension method that looks a little like...

```csharp
public static IServiceCollection ScanStatic(
    this IServiceCollection services,
    Action<ICompiledAssemblySelector> action,
    [CallerFilePathAttribute] string filePath = """",
    [CallerMemberName] string memberName = """",
    [CallerLineNumberAttribute] int lineNumber = 0
)
{
    return PopulateExtensions.Populate(services, RegistrationStrategy.Append, filePath, memberName, lineNumber);
}
```

`PopulateExtensions` is also emitted later based on the `action` that was sent to each `ScanStatic` method.

An example from the initial unit tests is like below.  Basically we just piggy back off the fact that `CallerXyz` attributes are emitted at compile time, and we can get those values during source generation as well.



```csharp

public static IServiceCollection Populate(IServiceCollection services, RegistrationStrategy strategy, string filePath, string memberName, int lineNumber)
{
    switch (lineNumber)
    {
        case 11:
            switch (filePath)
            {
                case ""Test1.cs"":
                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(Service), typeof(Service), ServiceLifetime.Singleton));
                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IService), _ => _.GetRequiredService(typeof(Service)), ServiceLifetime.Singleton));
                    break;
                case ""Test2.cs"":
                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(ServiceB), typeof(ServiceB), ServiceLifetime.Scoped));
                    strategy.Apply(services, ServiceDescriptor.Describe(typeof(IServiceB), _ => _.GetRequiredService(typeof(ServiceB)), ServiceLifetime.Scoped));
                    break;
            }

            break;
    }

    return services;
}
```

The I'm currently using the precedence of `LineNumber` -> `FilePath` -> `MemberName` instead of `FilePath` -> `MemberName` -> `LineNumber`

1) Line number will largely be different between between other files.
2) It's likely that `ScanStatic` will be called from the same file a few different times, requiring two jumps.
3) It's unlikely (however possible) that you could have a method on the same line, same file with two different member names. 
  * God forbid anyone code like `void A(IServiceCollection services) { services.ScanStatic(z => z.FromAssemblies().AddClasses(); }  void B(IServiceCollection services) { services.ScanStatic(z => z.FromAssemblies().AddClasses(); }` all on one line.

Assuming all unique line numbers, then we only have to deal with one switch before we start adding services, hopefully this adds as little overhead as possible (compared to full assembly scanning anyway).


- [ ] Review if the concept makes sense to @khellang 
- [x] Needs more unit tests
- [x] Needs testing related to generic types
- [x] Need to add diagnostics, everything has to be static inside the action `<T>` or `typeof()`

Let me know what you think!