### PR TITLE
adds netcoreapp3.1 target framework

### DIFF
--- a/src/Scrutor/IFluentInterface.cs
+++ b/src/Scrutor/IFluentInterface.cs
@@ -13,7 +13,7 @@ namespace Scrutor
         int GetHashCode();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        string ToString();
+        string? ToString();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool Equals(object obj);

--- a/src/Scrutor/ImplementationTypeFilter.cs
+++ b/src/Scrutor/ImplementationTypeFilter.cs
@@ -86,7 +86,7 @@ namespace Scrutor
         {
             Preconditions.NotNull(types, nameof(types));
 
-            return InNamespaces(types.Select(t => t.Namespace));
+            return InNamespaces(types.Select(t => t.Namespace!));
         }
 
         public IImplementationTypeFilter InNamespaces(params string[] namespaces)
@@ -104,7 +104,7 @@ namespace Scrutor
         public IImplementationTypeFilter InExactNamespaceOf(params Type[] types)
         {
             Preconditions.NotNull(types, nameof(types));
-            return Where(t => types.Any(x => t.IsInExactNamespace(x.Namespace)));
+            return Where(t => types.Any(x => t.IsInExactNamespace(x.Namespace!)));
         }
 
         public IImplementationTypeFilter InExactNamespaces(params string[] namespaces)
@@ -130,7 +130,7 @@ namespace Scrutor
         {
             Preconditions.NotNull(types, nameof(types));
 
-            return NotInNamespaces(types.Select(t => t.Namespace));
+            return NotInNamespaces(types.Select(t => t.Namespace!));
         }
 
         public IImplementationTypeFilter NotInNamespaces(params string[] namespaces)

--- a/src/Scrutor/NullableAttributes.cs
+++ b/src/Scrutor/NullableAttributes.cs
@@ -4,6 +4,8 @@
 
 // Copied from https://github.com/dotnet/coreclr/blob/16697076c0a6af47fbcce75e11c45d35a12b7d4e/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 
+#if NET461 || NETSTANDARD
+
 // ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis
 {
@@ -84,3 +86,5 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ParameterValue { get; }
     }
 }
+
+#endif

--- a/src/Scrutor/Scrutor.csproj
+++ b/src/Scrutor/Scrutor.csproj
@@ -3,7 +3,7 @@
     <Description>Register services using assembly scanning and a fluent API.</Description>
     <VersionPrefix>3.2.2</VersionPrefix>
     <Authors>Kristian Hellang</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,10 +27,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
   </ItemGroup>
 </Project>

--- a/src/Scrutor/TypeNameHelper.cs
+++ b/src/Scrutor/TypeNameHelper.cs
@@ -93,19 +93,19 @@ namespace Microsoft.Extensions.Internal
         private static void ProcessArrayType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
             var innerType = type;
-            while (innerType.IsArray)
+            while (innerType!.IsArray)
             {
                 innerType = innerType.GetElementType();
             }
 
             ProcessType(builder, innerType, options);
 
-            while (type.IsArray)
+            while (type!.IsArray)
             {
                 builder.Append('[');
                 builder.Append(',', type.GetArrayRank() - 1);
                 builder.Append(']');
-                type = type.GetElementType();
+                type = type.GetElementType()!;
             }
         }
 
@@ -114,14 +114,14 @@ namespace Microsoft.Extensions.Internal
             var offset = 0;
             if (type.IsNested)
             {
-                offset = type.DeclaringType.GetTypeInfo().GenericTypeArguments.Length;
+                offset = type.DeclaringType!.GetTypeInfo().GenericTypeArguments.Length;
             }
 
             if (options.FullName)
             {
                 if (type.IsNested)
                 {
-                    ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, options);
+                    ProcessGenericType(builder, type.DeclaringType!, genericArguments, offset, options);
                     builder.Append('+');
                 }
                 else if (!string.IsNullOrEmpty(type.Namespace))

--- a/src/Scrutor/TypeSourceSelector.cs
+++ b/src/Scrutor/TypeSourceSelector.cs
@@ -29,7 +29,7 @@ namespace Scrutor
 
         public IImplementationTypeSelector FromEntryAssembly()
         {
-            return FromAssemblies(Assembly.GetEntryAssembly());
+            return FromAssemblies(Assembly.GetEntryAssembly()!);
         }
 
         public IImplementationTypeSelector FromApplicationDependencies()
@@ -47,7 +47,7 @@ namespace Scrutor
             {
                 // Something went wrong when loading the DependencyContext, fall
                 // back to loading all referenced assemblies of the entry assembly...
-                return FromAssemblyDependencies(Assembly.GetEntryAssembly());
+                return FromAssemblyDependencies(Assembly.GetEntryAssembly()!);
             }
         }
 

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -8,9 +8,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds `netcoreapp3.1` to the target frameworks and fixes #127 .

For the existing target frameworks it keeps the current package versions. For netcoreapp3.1, it uses the most recent versions of _Microsoft.Extensions.DependencyInjection.Abstractions_ and _Microsoft.Extensions.DependencyModel_.

To fix the nullable issues [mentioned](https://github.com/khellang/Scrutor/issues/127#issuecomment-688508287) by @mbp, I added the `!` (null-forgiving) operator. To me it looks save; if the affected fields had been `null` in the past, you would have already got `NullReferenceException`s.