### PR TITLE
Covering issue #148, #117

### DIFF
--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -359,6 +359,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
 
                 // Since implementationType is equal to ServiceType we need explicitly create an implementation type through reflections in order to avoid infinite recursion.
+                // Should not cause issue with singletons, since singleton will be a decorator and after this fact we can don't care about lifecycle of decorable service (for sure, if IDisposable of decorator disposes underlying type:)) 
                 return provider.CreateInstance(implementationType);
             }
 

--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -299,19 +299,29 @@ namespace Microsoft.Extensions.DependencyInjection
 
             foreach (var descriptor in descriptors)
             {
-                var index = services.IndexOf(descriptor);
-
                 // To avoid reordering descriptors, in case a specific order is expected.
-                services[index] = decorator(descriptor);
+                services[descriptor.Position] = decorator(descriptor.Value);
             }
 
             error = default;
             return true;
         }
 
-        private static bool TryGetDescriptors(this IServiceCollection services, Type serviceType, out ICollection<ServiceDescriptor> descriptors)
+        private static bool TryGetDescriptors(this IServiceCollection services, Type serviceType, out IReadOnlyList<(int Position, ServiceDescriptor Value)> descriptors)
         {
-            return (descriptors = services.Where(service => service.ServiceType == serviceType).ToArray()).Any();
+            IEnumerable<(int Position, ServiceDescriptor Value)> __GetDescriptors()
+            {
+                for (int i = 0; i < services.Count; ++i)
+                {
+                    ServiceDescriptor serviceDescriptor = services[i];
+                    if (serviceDescriptor.ServiceType == serviceType)
+                        yield return (i, serviceDescriptor);
+                }
+            }
+
+            descriptors = __GetDescriptors().ToArray();
+
+            return descriptors.Count != 0;
         }
 
         private static ServiceDescriptor Decorate<TService>(this ServiceDescriptor descriptor, Func<TService, IServiceProvider, TService> decorator)

--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -351,9 +351,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 return descriptor.ImplementationInstance;
             }
 
-            if (descriptor.ImplementationType != null)
+            // Not suppose to be abstract. 
+            Type implementationType = descriptor.ImplementationType;
+            if (implementationType != null)
             {
-                return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
+                if (implementationType != descriptor.ServiceType)
+                    return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
+
+                // Since implementationType is equal to ServiceType we need explicitly create an implementation type through reflections in order to avoid infinite recursion.
+                return provider.CreateInstance(implementationType);
             }
 
             return descriptor.ImplementationFactory(provider);

--- a/test/Scrutor.Tests/DecorationTests.cs
+++ b/test/Scrutor.Tests/DecorationTests.cs
@@ -217,6 +217,24 @@ namespace Scrutor.Tests
             Assert.Throws<MissingTypeRegistrationException>(() => ConfigureProvider(services => services.Decorate<IDecoratedService, Decorator>()));
         }
 
+        [Fact]
+        public void Issue148_Decorate_IsAbleToDecorateConcreateTypes()
+        {
+            var sp = ConfigureProvider(sc =>
+            {
+                sc
+                    .AddTransient<IService, SomeRandomService>()
+                    .AddTransient<DecoratedService>()
+                    .Decorate<DecoratedService, Decorator2>();
+            });
+
+            var result = sp.GetService<DecoratedService>() as Decorator2;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Inner);
+            Assert.NotNull(result.Inner.Dependency);
+        }
+
         public interface IDecoratedService { }
 
         public interface IService { }
@@ -231,6 +249,28 @@ namespace Scrutor.Tests
             }
 
             public IService InjectedService { get; }
+        }
+
+
+        public class DecoratedService
+        {
+            public DecoratedService(IService dependency)
+            {
+                Dependency = dependency;
+            }
+
+            public IService Dependency { get; }
+        }
+
+        public class Decorator2 : DecoratedService
+        {
+            public Decorator2(DecoratedService decoratedService)
+                : base(null)
+            {
+                Inner = decoratedService;
+            }
+
+            public DecoratedService Inner { get; }
         }
 
         public class Decorator : IDecoratedService


### PR DESCRIPTION
This PR suppose to cover #148 #117. The problem was that decorable service was registered, most likely, as self. Which causing recursion according to a previous logic. Now, we are comparing the `ImplementationType` and `ServiceType` of the existing descriptors before decoration. If they are equal, this means that we cannot use `ActivatorUtilities.GetServiceOrCreateInstance` in the new descriptor, and the factory for it should use `ActivatorUtilities.CreateInstance`.

Described issue covered in separate test `Issue148_Decorate_IsAbleToDecorateConcreateTypes`.