### PR TITLE
- Fix issues #148 #117

### DIFF
--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (implementationType != null)
             {
                 if (implementationType != descriptor.ServiceType)
-                    return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
+                    return provider.GetServiceOrCreateInstance(implementationType);
 
                 // Since implementationType is equal to ServiceType we need explicitly create an implementation type through reflections in order to avoid infinite recursion.
                 // Should not cause issue with singletons, since singleton will be a decorator and after this fact we can don't care about lifecycle of decorable service (for sure, if IDisposable of decorator disposes underlying type:))

--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -341,9 +341,16 @@ namespace Microsoft.Extensions.DependencyInjection
                 return descriptor.ImplementationInstance;
             }
 
-            if (descriptor.ImplementationType != null)
+            // Not suppose to be abstract. 
+            Type implementationType = descriptor.ImplementationType;
+            if (implementationType != null)
             {
-                return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
+                if (implementationType != descriptor.ServiceType)
+                    return provider.GetServiceOrCreateInstance(descriptor.ImplementationType);
+
+                // Since implementationType is equal to ServiceType we need explicitly create an implementation type through reflections in order to avoid infinite recursion.
+                // Should not cause issue with singletons, since singleton will be a decorator and after this fact we can don't care about lifecycle of decorable service (for sure, if IDisposable of decorator disposes underlying type:))
+                return provider.CreateInstance(implementationType);
             }
 
             return descriptor.ImplementationFactory(provider);

--- a/test/Scrutor.Tests/DecorationTests.cs
+++ b/test/Scrutor.Tests/DecorationTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using System.Linq;
-using static Scrutor.Tests.DecorationTests;
 
 namespace Scrutor.Tests
 {


### PR DESCRIPTION
This PR suppose to cover #148 #117. The problem was that decorable service was registered, most likely, as self. Which causing recursion according to a previous logic. Now, we are comparing the `ImplementationType` and `ServiceType` of the existing descriptors before decoration. If they are equal, this means that we cannot use `ActivatorUtilities.GetServiceOrCreateInstance` in the new descriptor, and the factory for it should use `ActivatorUtilities.CreateInstance`.

Described issue covered in separate test `Issue148_Decorate_IsAbleToDecorateConcreateTypes`.