### PR TITLE
Select behavior for RegistrationStrategy.Skip #167

### DIFF
--- a/src/Scrutor/RegistrationStrategy.cs
+++ b/src/Scrutor/RegistrationStrategy.cs
@@ -1,14 +1,27 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Linq;
 
 namespace Scrutor;
 
 public abstract class RegistrationStrategy
 {
     /// <summary>
-    /// Skips registrations for services that already exists.
+    /// Skips registrations for services that already exist using <see cref="ReplacementBehavior.Default"/>.
     /// </summary>
-    public static readonly RegistrationStrategy Skip = new SkipRegistrationStrategy();
+    public static RegistrationStrategy Skip()
+    {
+        return new SkipRegistrationStrategy(SkipBehavior.Default);
+    }
+
+    /// <summary>
+    /// Skips registrations for services that already exist based on the specified <see cref="ReplacementBehavior"/>.
+    /// </summary>
+    /// <param name="behavior">The behavior to use when replacing services.</param>
+    public static RegistrationStrategy Skip(SkipBehavior behavior)
+    {
+        return new SkipRegistrationStrategy(behavior);
+    }
 
     /// <summary>
     /// Appends a new registration for existing services.
@@ -38,7 +51,7 @@ public abstract class RegistrationStrategy
     }
 
     /// <summary>
-    /// Applies the the <see cref="ServiceDescriptor"/> to the <see cref="IServiceCollection"/>.
+    /// Applies the selected <see cref="RegistrationStrategy"/> for the <see cref="ServiceDescriptor"/> to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="descriptor">The descriptor to apply.</param>
@@ -46,7 +59,31 @@ public abstract class RegistrationStrategy
 
     private sealed class SkipRegistrationStrategy : RegistrationStrategy
     {
-        public override void Apply(IServiceCollection services, ServiceDescriptor descriptor) => services.TryAdd(descriptor);
+        public SkipRegistrationStrategy(SkipBehavior behavior)
+        {
+            Behavior = behavior;
+        }
+
+        private SkipBehavior Behavior { get; }
+
+        public override void Apply(IServiceCollection services, ServiceDescriptor descriptor)
+        {
+            if (Behavior is SkipBehavior.Default or SkipBehavior.ServiceType)
+            {
+                services.TryAdd(descriptor);
+            }
+            else if (Behavior is SkipBehavior.ImplementationType)
+            {
+                if (!services.Any((ServiceDescriptor d) => d.ImplementationType == descriptor.ImplementationType))
+                {
+                    services.Add(descriptor);
+                }
+            }
+            else
+            {
+                services.TryAddEnumerable(descriptor);
+            }
+        }
     }
 
     private sealed class AppendRegistrationStrategy : RegistrationStrategy

--- a/src/Scrutor/ReplacementBehavior.cs
+++ b/src/Scrutor/ReplacementBehavior.cs
@@ -21,7 +21,7 @@ public enum ReplacementBehavior
     ImplementationType = 2,
 
     /// <summary>
-    /// Replace existing services by either service- or implementation type.
+    /// Replace existing services by either service or implementation type.
     /// </summary>
     All = ServiceType | ImplementationType
 }

--- a/src/Scrutor/SkipBehavior.cs
+++ b/src/Scrutor/SkipBehavior.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Scrutor;
+
+public enum SkipBehavior
+{
+    /// <summary>
+    /// Skip registration if the service type has already been registered. Same as <see cref="ServiceCollectionDescriptorExtensions.TryAdd(IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceDescriptor)"/>.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Skip registration if the service type has already been registered (default). Same as <see cref="ServiceCollectionDescriptorExtensions.TryAdd(IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceDescriptor)"/>.
+    /// </summary>
+    ServiceType = 1,
+
+    /// <summary>
+    /// Skip registration if the implementation type has already been registered.
+    /// </summary>
+    ImplementationType = 2,
+
+    /// <summary>
+    /// Skip registration if a descriptor with the same <see cref="ServiceDescriptor.ServiceType"/> and implementation has already been registered.
+    /// </summary>
+    Exact = 3,
+}
+


### PR DESCRIPTION
Hey, I added support for variable skip registration #167.
Skip can be configured to skip registration depending on the selected behavior. `SkipBehavior` has 4 states `Default`, `ServiceType`, `SkipBehavior` and `Exact`, which use `TryAdd` (for default and service type), a tweaked version of `TryAdd` and `TryAddEnumerable` respectively. 

Added some basic test in line with the other `RegistrationStrategy` methods, each test checks the right number of services are registered and that the older descriptor is registered. 

I'm pretty sure this is a breaking change, the new `Skip` method could be renamed to `SkipBy` so code using the old `UsingRegistrationStrategy(RegistrationStrategy.Skip)` would still be valid. 

Hopefully this is useful, Thanks!