### PR TITLE
Support for generic ServiceDescriptor from langVersion 11+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
               with:
                   dotnet-version: "3.1.x"
 
-            - name: Setup .NET 6 SDK
+            - name: Setup .NET 7 SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "6.0.x"
+                  dotnet-version: "7.0.x"
 
             - name: Test
               run: dotnet test --collect:"XPlat Code Coverage"

--- a/src/Scrutor/Scrutor.csproj
+++ b/src/Scrutor/Scrutor.csproj
@@ -5,7 +5,7 @@
     <Authors>Kristian Hellang</Authors>
     <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Scrutor/ServiceDescriptorAttribute.cs
+++ b/src/Scrutor/ServiceDescriptorAttribute.cs
@@ -52,3 +52,12 @@ public class ServiceDescriptorAttribute : Attribute
         yield return ServiceType;
     }
 }
+
+[PublicAPI]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class ServiceDescriptorAttribute<TService> : ServiceDescriptorAttribute
+{
+    public ServiceDescriptorAttribute() : base(typeof(TService)) { }
+
+    public ServiceDescriptorAttribute(ServiceLifetime lifetime) : base(typeof(TService), lifetime) { }
+}

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
@@ -9,17 +9,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi!
I have added support for generic attributes from language version 11+
```csharp
[ServiceDescriptor(typeof(IMixedAttribute), ServiceLifetime.Singleton)]
[ServiceDescriptor<IMixedAttribute>(ServiceLifetime.Singleton)]
```
but I am not sure if you want to update language version only for this feature.