### PR TITLE
Update target frameworks for .NET 6, .NET Framework 4.6.2, .NET Standard 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: windows-latest
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         env:
@@ -16,15 +16,12 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Setup .NET Core SDK
-              uses: actions/setup-dotnet@v1
+            - name: Setup .NET SDK
+              uses: actions/setup-dotnet@v3
               with:
-                  dotnet-version: "3.1.x"
-
-            - name: Setup .NET 7 SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "7.0.x"
+                  dotnet-version: |
+                    6.0.x
+                    7.0.x
 
             - name: Test
               run: dotnet test --collect:"XPlat Code Coverage"

--- a/src/Scrutor/Scrutor.csproj
+++ b/src/Scrutor/Scrutor.csproj
@@ -3,7 +3,7 @@
     <Description>Register services using assembly scanning and a fluent API.</Description>
     <VersionPrefix>4.2.2</VersionPrefix>
     <Authors>Kristian Hellang</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -30,12 +30,8 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.25" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.25" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-  </ItemGroup>
 </Project>

--- a/src/Scrutor/Scrutor.csproj
+++ b/src/Scrutor/Scrutor.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
   </ItemGroup>

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
@@ -15,11 +15,8 @@
     <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
+  
 </Project>

--- a/test/Scrutor.Tests/Scrutor.Tests.csproj
+++ b/test/Scrutor.Tests/Scrutor.Tests.csproj
@@ -9,14 +9,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="All" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
 What's changed?
- Target frameworks now: .NET 6, .NET Framework 4.6.2, .NET Standard 2.0
- Run tests for .NET 6, .NET 7, .NET Framework 4.6.2
- Update some nuget packages

Why target frameworks were changed?

Microsoft recommend to target .NET 6, .NET Standard and minimal supported .NET Framework
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/older-framework-versions-dropped

Notes:
.NET Framework 4.6.1 is out of support, .NET Framework 4.6.2 is the older version that is still supported
https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/

.NET Core 3.1 is out of support
https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/

