### PR TITLE
Add Select method to IImplementationTypeFilter

### DIFF
--- a/src/Scrutor/IImplementationTypeFilter.cs
+++ b/src/Scrutor/IImplementationTypeFilter.cs
@@ -155,4 +155,11 @@ public interface IImplementationTypeFilter : IFluentInterface
     /// <param name="predicate">The predicate to match types.</param>
     /// <exception cref="ArgumentNullException">If the <paramref name="predicate" /> argument is <c>null</c>.</exception>
     IImplementationTypeFilter Where(Func<Type, bool> predicate);
+    
+    /// <summary>
+    /// Will transform the types using the specified <paramref name="selector"/>.
+    /// </summary>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <exception cref="ArgumentNullException">If the <paramref name="selector" /> argument is <c>null</c>.</exception>
+    IImplementationTypeFilter Select(Func<Type, Type> selector);
 }

--- a/src/Scrutor/ImplementationTypeFilter.cs
+++ b/src/Scrutor/ImplementationTypeFilter.cs
@@ -154,4 +154,12 @@ internal class ImplementationTypeFilter : IImplementationTypeFilter
         Types = Types.Where(predicate);
         return this;
     }
+
+    public IImplementationTypeFilter Select(Func<Type, Type> selector)
+    {
+        Preconditions.NotNull(selector, nameof(selector));
+
+        Types = Types.Select(selector);
+        return this;
+    }
 }

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -429,6 +429,20 @@ namespace Scrutor.Tests
         }
 
         [Fact]
+        public void ShouldRegisterPartiallyOpenGenericTypesUsingSelect()
+        {
+            Collection.Scan(scan => scan.FromAssemblyOf<IDto>()
+                .AddClasses(classes =>
+                    classes.AssignableTo<IDto>().Select(x => typeof(ProcessDtoCommandHandler<>).MakeGenericType(x)))
+                .AsImplementedInterfaces());
+
+            var provider = Collection.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<ICommandHandler<ProcessDto<FooDto>>>());
+            Assert.NotNull(provider.GetService<ICommandHandler<ProcessDto<BarDto>>>());
+        }
+
+        [Fact]
         public void ShouldNotIncludeCompilerGeneratedTypes()
         {
             Assert.Empty(Collection.Scan(scan => scan.FromType<CompilerGenerated>()));
@@ -556,6 +570,17 @@ namespace Scrutor.Tests
     public interface IOpenGeneric<T> : IOtherInheritance { }
 
     public class OpenGeneric<T> : IOpenGeneric<T> { }
+    
+    public interface ICommandHandler<T> { }
+    
+    public class ProcessDto<T> where T : IDto { }
+    public class ProcessDtoCommandHandler<T> : ICommandHandler<ProcessDto<T>> where T : IDto { }
+    
+    public interface IDto {}
+    
+    public record FooDto : IDto {}
+    
+    public record BarDto : IDto {}
 
     public interface IPartiallyClosedGeneric<T1, T2> { }
 


### PR DESCRIPTION
Made an attempt to "fix" #96, by adding a `Select` method to the `IImplementationTypeFilter` interface that then allows the matched types to be transformed. Can now register such types like so:

```
services.Scan(scan => scan.FromAssemblyOf<IBaseEntity>()
  .AddClasses(classes => classes.AssignableTo<IBaseEntity>().Select(type => typeof(GetOneByIdHandler<>).MakeGenericType(type)))
  .AsImplementedInterfaces());
```