### PR TITLE
adds interface filtering for AsSelfWithInterfaces

### DIFF
--- a/src/Scrutor/IServiceTypeSelector.cs
+++ b/src/Scrutor/IServiceTypeSelector.cs
@@ -47,6 +47,12 @@ public interface IServiceTypeSelector : IImplementationTypeSelector
     ILifetimeSelector AsSelfWithInterfaces();
 
     /// <summary>
+    /// Registers each matching concrete type as all of its implemented interfaces, by returning an instance of the main type
+    /// </summary>
+    /// <param name="predicate">A predicate to filter which interfaces to register.</param>
+    ILifetimeSelector AsSelfWithInterfaces(Func<Type, bool> predicate);
+
+    /// <summary>
     /// Registers the type with the first found matching interface name.  (e.g. ClassName is matched to IClassName)
     /// </summary>
     ILifetimeSelector AsMatchingInterface();

--- a/src/Scrutor/LifetimeSelector.cs
+++ b/src/Scrutor/LifetimeSelector.cs
@@ -169,6 +169,11 @@ internal sealed class LifetimeSelector : ILifetimeSelector, ISelector
         return Inner.AsSelfWithInterfaces();
     }
 
+    public ILifetimeSelector AsSelfWithInterfaces(Func<Type, bool> predicate)
+    {
+        return Inner.AsSelfWithInterfaces(predicate);
+    }
+
     public ILifetimeSelector AsMatchingInterface()
     {
         return Inner.AsMatchingInterface();

--- a/src/Scrutor/ServiceTypeSelector.cs
+++ b/src/Scrutor/ServiceTypeSelector.cs
@@ -64,6 +64,11 @@ internal class ServiceTypeSelector : IServiceTypeSelector, ISelector
 
     public ILifetimeSelector AsSelfWithInterfaces()
     {
+        return AsSelfWithInterfaces(_ => true);
+    }
+
+    public ILifetimeSelector AsSelfWithInterfaces(Func<Type, bool> predicate)
+    {
         IEnumerable<Type> Selector(Type type)
         {
             if (type.IsGenericTypeDefinition)
@@ -75,6 +80,7 @@ internal class ServiceTypeSelector : IServiceTypeSelector, ISelector
 
             return type.GetInterfaces()
                 .Where(x => x.HasMatchingGenericArity(type))
+                .Where(predicate)
                 .Select(x => x.GetRegistrationType(type));
         }
 

--- a/test/Scrutor.Tests/ScanningTests.cs
+++ b/test/Scrutor.Tests/ScanningTests.cs
@@ -519,6 +519,30 @@ namespace Scrutor.Tests
         }
 
         [Fact]
+        public void AsSelfWithInterfacesShouldFilterInterfaces()
+        {
+            var provider = ConfigureProvider(services =>
+            {
+                services.Scan(scan => scan
+                    .FromAssemblyOf<CombinedService2>()
+                    .AddClasses(classes => classes.AssignableTo<CombinedService2>())
+                    .AsSelfWithInterfaces(x => x == typeof(IDefault1) || x == typeof(CombinedService2))
+                    .WithSingletonLifetime());
+            });
+
+            var instance1 = provider.GetRequiredService<CombinedService2>();
+            var instance2 = provider.GetRequiredService<IDefault1>();
+            var instance3 = provider.GetService<IDefault2>();
+            var instance4 = provider.GetService<IDefault3Level2>();
+            var instance5 = provider.GetService<IDefault3Level1>();
+
+            Assert.Same(instance1, instance2);
+            Assert.Null(instance3);
+            Assert.Null(instance4);
+            Assert.Null(instance5);
+        }
+
+        [Fact]
         public void AsSelfWithInterfacesHandlesOpenGenericTypes()
         {
             ConfigureProvider(services =>


### PR DESCRIPTION
I'm finding that if lifetimes are important either Scoped/Singleton the SelfWithInterfaces is needed to guarantee one instance. However, if we want to limit the interfaces used and registered the method will need interface filtering similar to how it's done with `AsImplementedInterfaces`.