### PR TITLE
Update TypeSourceSelector.cs

### DIFF
--- a/src/Scrutor/TypeSourceSelector.cs
+++ b/src/Scrutor/TypeSourceSelector.cs
@@ -154,7 +154,7 @@ public class TypeSourceSelector : ITypeSourceSelector, ISelector
 
     private IImplementationTypeSelector InternalFromAssemblies(IEnumerable<Assembly> assemblies)
     {
-        return AddSelector(assemblies.SelectMany(asm => asm.DefinedTypes).Select(x => x.AsType()));
+        return AddSelector(assemblies.SelectMany(asm => asm.ExportedTypes);
     }
 
     private static IEnumerable<Assembly> LoadAssemblies(IEnumerable<AssemblyName> assemblyNames)

--- a/src/Scrutor/TypeSourceSelector.cs
+++ b/src/Scrutor/TypeSourceSelector.cs
@@ -154,7 +154,7 @@ public class TypeSourceSelector : ITypeSourceSelector, ISelector
 
     private IImplementationTypeSelector InternalFromAssemblies(IEnumerable<Assembly> assemblies)
     {
-        return AddSelector(assemblies.SelectMany(asm => asm.ExportedTypes);
+        return AddSelector(assemblies.SelectMany(asm => asm.ExportedTypes));
     }
 
     private static IEnumerable<Assembly> LoadAssemblies(IEnumerable<AssemblyName> assemblyNames)


### PR DESCRIPTION
https://github.com/dotnet/SqlClient/issues/1930

> I had the same issue here. After changing to GetExportedTypes() seems to fix the issue

Hey! Got into trouble with .NET 8. If you look through the thread above you can see why I made the proposed change.