### PR TITLE
Fix AddClasses method to take only public classes not private

### DIFF
--- a/src/Scrutor/ImplementationTypeSelector.cs
+++ b/src/Scrutor/ImplementationTypeSelector.cs
@@ -35,7 +35,7 @@ internal class ImplementationTypeSelector : IImplementationTypeSelector, ISelect
 
     public IServiceTypeSelector AddClasses(Action<IImplementationTypeFilter> action)
     {
-        return AddClasses(action, publicOnly: false);
+        return AddClasses(action, publicOnly: true);
     }
 
     public IServiceTypeSelector AddClasses(Action<IImplementationTypeFilter> action, bool publicOnly)


### PR DESCRIPTION
Documentation of method IImplementationTypeSelector.AddClasses(Action<IImplementationTypeFilter> action) says that "Adds all public, non-abstract classes from the selected assemblies that" but in implementation this method takes private classes too:
AddClasses(action, publicOnly: false).

Sync code with documentation.