### PR TITLE
ActivatorUtilities.CreateFactory created breaking change from version 4.2.2 to 5.0.1

### DIFF
--- a/src/Scrutor/DecorationStrategy.cs
+++ b/src/Scrutor/DecorationStrategy.cs
@@ -30,11 +30,10 @@ public abstract class DecorationStrategy
 
     protected static Func<IServiceProvider, object?, object> TypeDecorator(Type serviceType, string serviceKey, Type decoratorType)
     {
-        var factory = ActivatorUtilities.CreateFactory(decoratorType, new[] { serviceType });
         return (serviceProvider, _) =>
         {
             var instanceToDecorate = serviceProvider.GetRequiredKeyedService(serviceType, serviceKey);
-            return factory(serviceProvider, new object[] { instanceToDecorate });
+            return ActivatorUtilities.CreateInstance(serviceProvider, decoratorType, instanceToDecorate);
         };
     }
 

--- a/test/Scrutor.Tests/DecorationTests.cs
+++ b/test/Scrutor.Tests/DecorationTests.cs
@@ -236,6 +236,23 @@ public class DecorationTests : TestBase
         Assert.NotNull(inner.Dependency);
     }
 
+    [Fact]
+    public void Issue235_Decorate_IsAbleToDecorateClassesThatTheirConstructorDoesNotContainTheDecoratedTypeDirectly()
+    {
+        var provider = ConfigureProvider(services =>
+        {
+            services.AddScoped<Decorated>()
+                    .AddScoped<IDecoratedService>(x => x.GetRequiredService<Decorated>())
+                    .Decorate<IDecoratedService, Decorator3>();
+        });
+
+        using (var scope = provider.CreateScope())
+        {
+            var result = scope.ServiceProvider.GetService<IDecoratedService>();
+            Assert.NotNull(result);
+        }
+    }
+
     #region Individual functions tests
 
     [Fact]
@@ -468,6 +485,16 @@ public class DecorationTests : TestBase
         }
 
         public DecoratedService Inner { get; }
+    }
+
+    public class Decorator3 : IDecoratedService
+    {
+        public Decorator3(Decorated inner)
+        {
+            Inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public Decorated Inner { get; }
     }
 
     public interface IService { }


### PR DESCRIPTION
This PR was created to solve #235, on the premise that upgrade from 4.2.2 to 5.0.1 should have no breaking changes, 

The reason for the issue is that for example Decorator3 does not request IDecoratedService but requests a concrete class that implements IDecoratedService.
This behavior is supported by ActivatorUtilities.CreateInstance since it uses the IServiceProvider to inject constructor arguments,
but ActivatorUtilities.CreateFactory expects the contructor to have IDecoratedService, which is not the case in this example.

```csharp
public class Decorated : IDecoratedService
{
        public Decorated(IService injectedService = null)
        {
            InjectedService = injectedService;
        }

        public IService InjectedService { get; }
}

public class Decorator3 : IDecoratedService
{
        public Decorator3(Decorated inner)
        {
            Inner = inner ?? throw new ArgumentNullException(nameof(inner));
        }

        public Decorated Inner { get; }
}
```

Thanks for all the hard work! 
Let me know what you think