### PR TITLE
Extend ILifetimeSelector with a new WithLifetime method that acepts a Func<Type, ServiceLifetime> parameter to map implementation type to service lifetime

### DIFF
--- a/src/Scrutor/ILifetimeSelector.cs
+++ b/src/Scrutor/ILifetimeSelector.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Scrutor;
 
@@ -23,4 +24,9 @@ public interface ILifetimeSelector : IServiceTypeSelector
     /// Registers each matching concrete type with the specified <paramref name="lifetime"/>.
     /// </summary>
     IImplementationTypeSelector WithLifetime(ServiceLifetime lifetime);
+
+    /// <summary>
+    /// Registers each matching concrete type with the specified <paramref name="lifetime"/>.
+    /// </summary>
+    IImplementationTypeSelector WithLifetime(Func<Type, ServiceLifetime> lifetime);
 }

--- a/src/Scrutor/ServiceTypeSelector.cs
+++ b/src/Scrutor/ServiceTypeSelector.cs
@@ -71,7 +71,7 @@ internal class ServiceTypeSelector : IServiceTypeSelector, ISelector
 
         return AddSelector(
             Types.Select(t => new TypeMap(t, new[] { t })),
-            Types.Select(t => new TypeFactoryMap(x => x.GetRequiredService(t), Selector(t, predicate))));
+            Types.Select(t => new TypeFactoryMap(x => x.GetRequiredService(t), Selector(t, predicate), t)));
 
         static IEnumerable<Type> Selector(Type type, Func<Type, bool> predicate)
         {
@@ -209,7 +209,7 @@ internal class ServiceTypeSelector : IServiceTypeSelector, ISelector
 
     #endregion
 
-    internal void PropagateLifetime(ServiceLifetime lifetime)
+    internal void PropagateLifetime(Func<Type, ServiceLifetime> lifetime)
     {
         foreach (var selector in Selectors.OfType<LifetimeSelector>())
         {

--- a/src/Scrutor/TypeFactoryMap.cs
+++ b/src/Scrutor/TypeFactoryMap.cs
@@ -5,13 +5,17 @@ namespace Scrutor;
 
 internal struct TypeFactoryMap
 {
-    public TypeFactoryMap(Func<IServiceProvider, object> implementationFactory, IEnumerable<Type> serviceTypes)
+    public TypeFactoryMap(Func<IServiceProvider, object> implementationFactory, IEnumerable<Type> serviceTypes, Type implementationType)
     {
         ImplementationFactory = implementationFactory;
         ServiceTypes = serviceTypes;
+        ImplementationType = implementationType;
     }
 
     public Func<IServiceProvider, object> ImplementationFactory { get; }
 
     public IEnumerable<Type> ServiceTypes { get; }
+
+    public Type ImplementationType { get; }
+
 }


### PR DESCRIPTION
Hello,

Thanks for the great library. One limitation currently stops be from fully adopting it in the project currently I work on (or maybe I am missing something and don't know how to do it).

Would you consider extending the `ILifetimeSelector` with a new `WithLifetime` method that accepts a `Func<Type, ServiceLifetime>` parameter, i.e. a function that maps an implementation type to a service lifetime?
This will allow registering services marked with a marker interface `IAppService`, but that have different lifetimes, something like this:
```
services.Scan(typeSourceSelector =>
{
    var assemblies = typeof(IAppService).Assembly;

    var serviceTypeSelector = typeSourceSelector
        .FromAssemblies(assemblies)
        .AddClasses(x => x.AssignableTo(typeof(IAppService)))
        .AsSelfWithInterfaces(x => typeof(IAppService).IsAssignableFrom(x) && typeof(IAppService) != x)
        .WithLifetime(implementationType => GetServiceLifeTime(implementationType));
});
```

Thanks