### PR TITLE
Fix KeyedService.AnyKey support 

### DIFF
--- a/src/Scrutor/DecorationStrategy.cs
+++ b/src/Scrutor/DecorationStrategy.cs
@@ -16,11 +16,8 @@ public abstract class DecorationStrategy
     public string? ServiceKey { get; }
 
     public virtual bool CanDecorate(ServiceDescriptor descriptor) =>
-        (
-            ReferenceEquals(ServiceKey, descriptor.ServiceKey)
-            || descriptor.ServiceKey is string serviceKey
-                && string.Equals(ServiceKey, serviceKey, StringComparison.Ordinal)
-        ) && CanDecorate(descriptor.ServiceType);
+        // object.Equals is used to support decorating services with object keys (e.g., KeyedService.AnyKey).
+        Equals(ServiceKey, descriptor.ServiceKey) && CanDecorate(descriptor.ServiceType);
 
     protected abstract bool CanDecorate(Type serviceType);
 

--- a/src/Scrutor/DecorationStrategy.cs
+++ b/src/Scrutor/DecorationStrategy.cs
@@ -16,7 +16,11 @@ public abstract class DecorationStrategy
     public string? ServiceKey { get; }
 
     public virtual bool CanDecorate(ServiceDescriptor descriptor) =>
-        string.Equals(ServiceKey, descriptor.ServiceKey as string, StringComparison.Ordinal) && CanDecorate(descriptor.ServiceType);
+        (
+            ReferenceEquals(ServiceKey, descriptor.ServiceKey)
+            || descriptor.ServiceKey is string serviceKey
+                && string.Equals(ServiceKey, serviceKey, StringComparison.Ordinal)
+        ) && CanDecorate(descriptor.ServiceType);
 
     protected abstract bool CanDecorate(Type serviceType);
 

--- a/test/Scrutor.Tests/DecorationTests.cs
+++ b/test/Scrutor.Tests/DecorationTests.cs
@@ -85,6 +85,26 @@ public class DecorationTests : TestBase
     }
 
     [Fact]
+    public void ShouldNotDecorateKeyedServiceWithNonKeyedDecorator()
+    {
+        var services = new ServiceCollection();
+
+        services.AddKeyedSingleton<IDecoratedService, OtherDecorated>(KeyedService.AnyKey);
+        services.AddSingleton<IDecoratedService, Decorated>();
+
+        services.Decorate<IDecoratedService, Decorator>();
+
+        var descriptors = services.GetDescriptors<IDecoratedService>();
+
+        Assert.Equal(3, descriptors.Length);
+
+        var nondecorated = descriptors.SingleOrDefault(x => x.IsKeyedService && x.KeyedImplementationType == typeof(OtherDecorated));
+
+        Assert.NotNull(nondecorated);
+        Assert.Equal(KeyedService.AnyKey, nondecorated.ServiceKey);
+    }
+
+    [Fact]
     public void CanDecorateExistingInstance()
     {
         var existing = new Decorated();


### PR DESCRIPTION
`DecorationException` is thrown if a non-keyed service and a keyed service are registered.

I think this is a bug since 5.0.3

This PR fix `Decorate` not to try decorate keyed service