### PR TITLE
Add keyed service registration support

### DIFF
--- a/src/Scrutor/AttributeSelector.cs
+++ b/src/Scrutor/AttributeSelector.cs
@@ -37,7 +37,7 @@ internal class AttributeSelector : ISelector
 
                 foreach (var serviceType in serviceTypes)
                 {
-                    var descriptor = new ServiceDescriptor(serviceType, type, attribute.Lifetime);
+                    var descriptor = new ServiceDescriptor(serviceType, attribute.ServiceKey, type, attribute.Lifetime);
 
                     strategy.Apply(services, descriptor);
                 }

--- a/src/Scrutor/ServiceDescriptorAttribute.cs
+++ b/src/Scrutor/ServiceDescriptorAttribute.cs
@@ -13,15 +13,20 @@ public class ServiceDescriptorAttribute : Attribute
 
     public ServiceDescriptorAttribute(Type? serviceType) : this(serviceType, ServiceLifetime.Transient) { }
 
-    public ServiceDescriptorAttribute(Type? serviceType, ServiceLifetime lifetime)
+    public ServiceDescriptorAttribute(Type? serviceType, ServiceLifetime lifetime) : this(serviceType, lifetime, null) { }
+
+    public ServiceDescriptorAttribute(Type? serviceType, ServiceLifetime lifetime, object? serviceKey)
     {
         ServiceType = serviceType;
         Lifetime = lifetime;
+        ServiceKey = serviceKey;
     }
 
     public Type? ServiceType { get; }
 
     public ServiceLifetime Lifetime { get; }
+
+    public object? ServiceKey { get; }
 
     public IEnumerable<Type> GetServiceTypes(Type fallbackType)
     {
@@ -60,4 +65,8 @@ public sealed class ServiceDescriptorAttribute<TService> : ServiceDescriptorAttr
     public ServiceDescriptorAttribute() : base(typeof(TService)) { }
 
     public ServiceDescriptorAttribute(ServiceLifetime lifetime) : base(typeof(TService), lifetime) { }
+
+    public ServiceDescriptorAttribute(object? serviceKey) : base(typeof(TService), ServiceLifetime.Transient, serviceKey) { }
+
+    public ServiceDescriptorAttribute(ServiceLifetime lifetime, object? serviceKey) : base(typeof(TService), lifetime, serviceKey) { }
 }


### PR DESCRIPTION
### Summary
This PR adds support for registering services with a service key in Scrutor. 
Currently, Scrutor does not provide a way to register keyed services. 
With this change, developers can specify a key when registering a service via `ServiceDescriptorAttribute`.

### Changes
- Modified `ServiceDescriptorAttribute` to allow an optional `ServiceKey` property.
- Updated registration logic to respect `ServiceKey` if provided.
- Preserved backward compatibility for existing code without keys.

### Motivation
Adding keyed services allows more flexible dependency injection scenarios, 
such as having multiple implementations of the same interface and selecting them by key at resolution time.

### Example
```csharp
[ServiceDescriptor(serviceType: typeof(IMyService), lifetime: ServiceLifetime.Transient, serviceKey: "specificService")]
public class MyService : IMyService { }
