### PR TITLE
Add support for exposing decorated services

### DIFF
--- a/src/Scrutor/DecoratedService.cs
+++ b/src/Scrutor/DecoratedService.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Scrutor;
+
+/// <summary>
+/// A handle to a decorated service. This can be used to resolve decorated services from an <see cref="IServiceProvider"/>
+/// using <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.
+/// </summary>
+/// <typeparam name="TService">The type of services which were decorated.</typeparam>
+public sealed class DecoratedService<TService>
+{
+    internal DecoratedService(Type serviceType, IReadOnlyList<string> serviceKeys)
+    {
+        if (!typeof(TService).IsAssignableFrom(serviceType))
+            throw new ArgumentException($"The type {serviceType} is not assignable to the service type {typeof(TService)}");
+
+        ServiceType = serviceType;
+        ServiceKeys = serviceKeys;
+    }
+
+    internal Type ServiceType { get; }
+    internal IReadOnlyList<string> ServiceKeys { get; } // In descending order of precedence
+
+    internal DecoratedService<TService2> Downcast<TService2>() => new(ServiceType, ServiceKeys);
+}

--- a/src/Scrutor/MaybeNullWhenAttribute.cs
+++ b/src/Scrutor/MaybeNullWhenAttribute.cs
@@ -1,0 +1,19 @@
+﻿#if NETFRAMEWORK
+
+using System;
+
+/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    /// <summary>Initializes the attribute with the specified return value condition.</summary>
+    /// <param name="returnValue">
+    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// </param>
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    /// <summary>Gets the return value condition.</summary>
+    public bool ReturnValue { get; }
+}
+
+#endif

--- a/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
+++ b/src/Scrutor/ServiceCollectionExtensions.Decoration.cs
@@ -1,6 +1,8 @@
 ﻿using Scrutor;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
+using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection;
@@ -20,9 +22,7 @@ public static partial class ServiceCollectionExtensions
     public static IServiceCollection Decorate<TService, TDecorator>(this IServiceCollection services)
         where TDecorator : TService
     {
-        Preconditions.NotNull(services, nameof(services));
-
-        return services.Decorate(typeof(TService), typeof(TDecorator));
+        return services.Decorate<TService, TDecorator>(out _);
     }
 
     /// <summary>
@@ -34,9 +34,7 @@ public static partial class ServiceCollectionExtensions
     public static bool TryDecorate<TService, TDecorator>(this IServiceCollection services)
         where TDecorator : TService
     {
-        Preconditions.NotNull(services, nameof(services));
-
-        return services.TryDecorate(typeof(TService), typeof(TDecorator));
+        return services.TryDecorate<TService, TDecorator>(out _);
     }
 
     /// <summary>
@@ -51,11 +49,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decoratorType"/> arguments are <c>null</c>.</exception>
     public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Type decoratorType)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decoratorType, nameof(decoratorType));
-
-        return services.Decorate(DecorationStrategy.WithType(serviceType, serviceKey: null, decoratorType));
+        return services.Decorate(serviceType, decoratorType, out _);
     }
 
     /// <summary>
@@ -69,11 +63,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decoratorType"/> arguments are <c>null</c>.</exception>
     public static bool TryDecorate(this IServiceCollection services, Type serviceType, Type decoratorType)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decoratorType, nameof(decoratorType));
-
-        return services.TryDecorate(DecorationStrategy.WithType(serviceType, serviceKey: null, decoratorType));
+        return services.TryDecorate(serviceType, decoratorType, out _);
     }
 
     /// <summary>
@@ -88,10 +78,7 @@ public static partial class ServiceCollectionExtensions
     /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static IServiceCollection Decorate<TService>(this IServiceCollection services, Func<TService, TService> decorator) where TService : notnull
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.Decorate<TService>((service, _) => decorator(service));
+        return services.Decorate<TService>(decorator, out _);
     }
 
     /// <summary>
@@ -105,10 +92,7 @@ public static partial class ServiceCollectionExtensions
     /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static bool TryDecorate<TService>(this IServiceCollection services, Func<TService, TService> decorator) where TService : notnull
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.TryDecorate<TService>((service, _) => decorator(service));
+        return services.TryDecorate<TService>(decorator, out _);
     }
 
     /// <summary>
@@ -123,10 +107,7 @@ public static partial class ServiceCollectionExtensions
     /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static IServiceCollection Decorate<TService>(this IServiceCollection services, Func<TService, IServiceProvider, TService> decorator) where TService : notnull
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.Decorate(typeof(TService), (service, provider) => decorator((TService)service, provider));
+        return services.Decorate<TService>(decorator, out _);
     }
 
     /// <summary>
@@ -140,10 +121,7 @@ public static partial class ServiceCollectionExtensions
     /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static bool TryDecorate<TService>(this IServiceCollection services, Func<TService, IServiceProvider, TService> decorator) where TService : notnull
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.TryDecorate(typeof(TService), (service, provider) => decorator((TService)service, provider));
+        return services.TryDecorate<TService>(decorator, out _);
     }
 
     /// <summary>
@@ -158,11 +136,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Func<object, object> decorator)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.Decorate(serviceType, (decorated, _) => decorator(decorated));
+        return services.Decorate(serviceType, decorator, out _);
     }
 
     /// <summary>
@@ -176,11 +150,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static bool TryDecorate(this IServiceCollection services, Type serviceType, Func<object, object> decorator)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.TryDecorate(serviceType, (decorated, _) => decorator(decorated));
+        return services.TryDecorate(serviceType, decorator, out _);
     }
 
     /// <summary>
@@ -195,11 +165,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Func<object, IServiceProvider, object> decorator)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.Decorate(DecorationStrategy.WithFactory(serviceType, serviceKey: null, decorator));
+        return services.Decorate(serviceType, decorator, out _);
     }
 
     /// <summary>
@@ -213,11 +179,7 @@ public static partial class ServiceCollectionExtensions
     /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
     public static bool TryDecorate(this IServiceCollection services, Type serviceType, Func<object, IServiceProvider, object> decorator)
     {
-        Preconditions.NotNull(services, nameof(services));
-        Preconditions.NotNull(serviceType, nameof(serviceType));
-        Preconditions.NotNull(decorator, nameof(decorator));
-
-        return services.TryDecorate(DecorationStrategy.WithFactory(serviceType, serviceKey: null, decorator));
+        return services.TryDecorate(serviceType, decorator, out _);
     }
 
     /// <summary>
@@ -228,7 +190,273 @@ public static partial class ServiceCollectionExtensions
     /// <exception cref="DecorationException">If no registered service matched the specified <paramref name="strategy"/>.</exception>
     public static IServiceCollection Decorate(this IServiceCollection services, DecorationStrategy strategy)
     {
-        if (services.TryDecorate(strategy))
+        return services.Decorate(strategy, out _);
+    }
+
+    /// <summary>
+    /// Decorates all registered services using the specified <paramref name="strategy"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="strategy">The strategy for decorating services.</param>
+    public static bool TryDecorate(this IServiceCollection services, DecorationStrategy strategy)
+    {
+        return services.TryDecorate(strategy, out _);
+    }
+
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the specified type <typeparamref name="TDecorator"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of the type <typeparamref name="TService"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If the <paramref name="services"/> argument is <c>null</c>.</exception>
+    public static IServiceCollection Decorate<TService, TDecorator>(this IServiceCollection services, out DecoratedService<TService> decorated)
+        where TDecorator : TService
+    {
+        Preconditions.NotNull(services, nameof(services));
+
+        services = services.Decorate(typeof(TService), typeof(TDecorator), out var decoratedObj);
+        decorated = decoratedObj.Downcast<TService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the specified type <typeparamref name="TDecorator"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If the <paramref name="services"/> argument is <c>null</c>.</exception>
+    public static bool TryDecorate<TService, TDecorator>(this IServiceCollection services, [NotNullWhen(true)] out DecoratedService<TService>? decorated)
+        where TDecorator : TService
+    {
+        Preconditions.NotNull(services, nameof(services));
+
+        var success = services.TryDecorate(typeof(TService), typeof(TDecorator), out var decoratedObj);
+        decorated = success ? decoratedObj!.Downcast<TService>() : null;
+        return success;
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the specified <paramref name="decoratorType"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decoratorType">The type to decorate existing services with.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of the specified <paramref name="serviceType"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decoratorType"/> arguments are <c>null</c>.</exception>
+    public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Type decoratorType, out DecoratedService<object> decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decoratorType, nameof(decoratorType));
+
+        return services.Decorate(DecorationStrategy.WithType(serviceType, serviceKey: null, decoratorType), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the specified <paramref name="decoratorType"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decoratorType">The type to decorate existing services with.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decoratorType"/> arguments are <c>null</c>.</exception>
+    public static bool TryDecorate(this IServiceCollection services, Type serviceType, Type decoratorType, [NotNullWhen(true)] out DecoratedService<object>? decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decoratorType, nameof(decoratorType));
+
+        return services.TryDecorate(DecorationStrategy.WithType(serviceType, serviceKey: null, decoratorType), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <typeparam name="TService">The type of services to decorate.</typeparam>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of <typeparamref name="TService"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>
+    /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static IServiceCollection Decorate<TService>(this IServiceCollection services, Func<TService, TService> decorator, out DecoratedService<TService> decorated) where TService : notnull
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.Decorate<TService>((service, _) => decorator(service), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <typeparam name="TService">The type of services to decorate.</typeparam>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>
+    /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static bool TryDecorate<TService>(this IServiceCollection services, Func<TService, TService> decorator, [NotNullWhen(true)] out DecoratedService<TService>? decorated) where TService : notnull
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.TryDecorate<TService>((service, _) => decorator(service), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <typeparam name="TService">The type of services to decorate.</typeparam>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of <typeparamref name="TService"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>
+    /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static IServiceCollection Decorate<TService>(this IServiceCollection services, Func<TService, IServiceProvider, TService> decorator, out DecoratedService<TService> decorated) where TService : notnull
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        services = services.Decorate(typeof(TService), (service, provider) => decorator((TService)service, provider), out var decoratedObj);
+        decorated = decoratedObj.Downcast<TService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Decorates all registered services of type <typeparamref name="TService"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <typeparam name="TService">The type of services to decorate.</typeparam>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>
+    /// or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static bool TryDecorate<TService>(this IServiceCollection services, Func<TService, IServiceProvider, TService> decorator, [NotNullWhen(true)] out DecoratedService<TService>? decorated) where TService : notnull
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        var success = services.TryDecorate(typeof(TService), (service, provider) => decorator((TService)service, provider), out var decoratedObj);
+        decorated = success ? decoratedObj!.Downcast<TService>() : null;
+        return success;
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of the specified <paramref name="serviceType"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Func<object, object> decorator, out DecoratedService<object> decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.Decorate(serviceType, (decorated, _) => decorator(decorated), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static bool TryDecorate(this IServiceCollection services, Type serviceType, Func<object, object> decorator, [NotNullWhen(true)] out DecoratedService<object>? decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.TryDecorate(serviceType, (decorated, _) => decorator(decorated), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no service of the specified <paramref name="serviceType"/> has been registered.</exception>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static IServiceCollection Decorate(this IServiceCollection services, Type serviceType, Func<object, IServiceProvider, object> decorator, out DecoratedService<object> decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.Decorate(DecorationStrategy.WithFactory(serviceType, serviceKey: null, decorator), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services of the specified <paramref name="serviceType"/>
+    /// using the <paramref name="decorator"/> function.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="serviceType">The type of services to decorate.</param>
+    /// <param name="decorator">The decorator function.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="ArgumentNullException">If either the <paramref name="services"/>,
+    /// <paramref name="serviceType"/> or <paramref name="decorator"/> arguments are <c>null</c>.</exception>
+    public static bool TryDecorate(this IServiceCollection services, Type serviceType, Func<object, IServiceProvider, object> decorator, [NotNullWhen(true)] out DecoratedService<object>? decorated)
+    {
+        Preconditions.NotNull(services, nameof(services));
+        Preconditions.NotNull(serviceType, nameof(serviceType));
+        Preconditions.NotNull(decorator, nameof(decorator));
+
+        return services.TryDecorate(DecorationStrategy.WithFactory(serviceType, serviceKey: null, decorator), out decorated);
+    }
+
+    /// <summary>
+    /// Decorates all registered services using the specified <paramref name="strategy"/>.
+    /// </summary>
+    /// <param name="services">The services to add to.</param>
+    /// <param name="strategy">The strategy for decorating services.</param>
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    /// <exception cref="DecorationException">If no registered service matched the specified <paramref name="strategy"/>.</exception>
+    public static IServiceCollection Decorate(this IServiceCollection services, DecorationStrategy strategy, out DecoratedService<object> decorated)
+    {
+        if (services.TryDecorate(strategy, out decorated!))
         {
             return services;
         }
@@ -241,12 +469,14 @@ public static partial class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The services to add to.</param>
     /// <param name="strategy">The strategy for decorating services.</param>
-    public static bool TryDecorate(this IServiceCollection services, DecorationStrategy strategy)
+    /// <param name="decorated">A handle to the service which was decorated. Using this, the service can be retrieved from the service provider via
+    /// <see cref="ServiceProviderExtensions.GetRequiredDecoratedService{TService}(IServiceProvider, DecoratedService{TService})"/>.</param>
+    public static bool TryDecorate(this IServiceCollection services, DecorationStrategy strategy, [NotNullWhen(true)] out DecoratedService<object>? decorated)
     {
         Preconditions.NotNull(services, nameof(services));
         Preconditions.NotNull(strategy, nameof(strategy));
 
-        var decorated = false;
+        var decoratedKeys = new List<string>();
 
         for (var i = services.Count - 1; i >= 0; i--)
         {
@@ -260,20 +490,22 @@ public static partial class ServiceCollectionExtensions
             var serviceKey = GetDecoratorKey(serviceDescriptor);
             if (serviceKey is null)
             {
+                decorated = null;
                 return false;
             }
 
             // Insert decorated
             services.Add(serviceDescriptor.WithServiceKey(serviceKey));
+            decoratedKeys.Add(serviceKey);
 
             // Replace decorator
             services[i] = serviceDescriptor.WithImplementationFactory(strategy.CreateDecorator(serviceDescriptor.ServiceType, serviceKey));
-
-            decorated = true;
         }
 
-        return decorated;
+        decorated = new DecoratedService<object>(strategy.ServiceType, decoratedKeys);
+        return decoratedKeys.Count > 0;
     }
+
 
     /// <summary>
     /// Returns <c>true</c> if the specified service is decorated.

--- a/src/Scrutor/ServiceProviderExtensions.cs
+++ b/src/Scrutor/ServiceProviderExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scrutor;
+
+public static class ServiceProviderExtensions
+{
+    /// <summary>
+    /// Get all decorated services of type <typeparamref name="TService"/> from the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <typeparam name="TService">The type of services which were decorated.</typeparam>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to retrieve the service objects from.</param>
+    /// <param name="decoratedType">A handle to a decorated service, obtainable from a <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.Decorate{TService, TDecorator}(IServiceCollection, out DecoratedService{TService})"/>
+    /// overload which omits one as an <c>out</c> parameter.</param>
+    /// <returns>A service object of type <typeparamref name="TService"/>.</returns>
+    public static IEnumerable<TService> GetDecoratedServices<TService>(this IServiceProvider serviceProvider, DecoratedService<TService> decoratedType)
+    {
+        return decoratedType.ServiceKeys.Reverse().Select(key => (TService)serviceProvider.GetRequiredKeyedService(decoratedType.ServiceType, key));
+    }
+
+    /// <summary>
+    /// Get decorated service of type <typeparamref name="TService"/> from the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <typeparam name="TService">The type of service which was decorated.</typeparam>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+    /// <param name="decoratedType">A handle to a decorated service, obtainable from a <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.Decorate{TService, TDecorator}(IServiceCollection, out DecoratedService{TService})"/>
+    /// overload which omits one as an <c>out</c> parameter.</param>
+    /// <returns>A service object of type <typeparamref name="TService"/>.</returns>
+    public static TService GetRequiredDecoratedService<TService>(this IServiceProvider serviceProvider, DecoratedService<TService> decoratedType)
+    {
+        return (TService)serviceProvider.GetRequiredKeyedService(decoratedType.ServiceType, decoratedType.ServiceKeys[0]);
+    }
+}


### PR DESCRIPTION
Resolves #184.

I wrapped the service key in an opaque handle in case you want to change the implementation of how this works again in future (it also makes it easier to ferry around the static type information).

I did feel kind of bad about duplicating every single Decorate and TryDecorate method but I couldn't see any other way to emit the information needed short of a hack like dropping it in some passive ambient state in a static class or something. I preferred the `out` parameter route.