### PR TITLE
Add support for service key registration

### DIFF
--- a/src/Scrutor/ILifetimeSelector.cs
+++ b/src/Scrutor/ILifetimeSelector.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Scrutor;
 
@@ -29,4 +29,16 @@ public interface ILifetimeSelector : IServiceTypeSelector
     /// Registers each matching concrete type with a lifetime based on the provided <paramref name="selector"/>.
     /// </summary>
     IImplementationTypeSelector WithLifetime(Func<Type, ServiceLifetime> selector);
+
+    /// <summary>
+    /// Registers each matching concrete type with the specified <paramref name="serviceKey"/>.
+    /// </summary>
+    /// <param name="serviceKey">The service key to use for registration.</param>
+    ILifetimeSelector WithServiceKey(object serviceKey);
+
+    /// <summary>
+    /// Registers each matching concrete type with a service key based on the provided <paramref name="selector"/>.
+    /// </summary>
+    /// <param name="selector">A function to determine the service key for each type.</param>
+    ILifetimeSelector WithServiceKey(Func<Type, object?> selector);
 }

--- a/src/Scrutor/ServiceTypeSelector.cs
+++ b/src/Scrutor/ServiceTypeSelector.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyModel;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyModel;
 
 namespace Scrutor;
 
@@ -204,6 +204,14 @@ internal class ServiceTypeSelector : IServiceTypeSelector, ISelector
         foreach (var selector in Selectors.OfType<LifetimeSelector>())
         {
             selector.SelectorFn = selectorFn;
+        }
+    }
+
+    internal void PropagateServiceKey(Func<Type, object?> selectorFn)
+    {
+        foreach (var selector in Selectors.OfType<LifetimeSelector>())
+        {
+            selector.ServiceKeySelectorFn = selectorFn;
         }
     }
 


### PR DESCRIPTION
## Overview

This PR adds support for keyed service registration in the `Scan` method, enabling compatibility with .NET 8's keyed dependency injection feature. This allows users to specify service keys during scanning, aligning with the `AddKeyedSingleton`/`AddKeyedScoped`/`AddKeyedTransient` pattern introduced in .NET 8.

## Problem

Previously, there was no way to register services with keys when using Scrutor's scanning capabilities. Users who wanted to leverage .NET 8's keyed DI feature had to manually register services, losing the benefits of convention-based scanning.

## Solution

Added two new methods to `ILifetimeSelector`:
- `WithServiceKey(object serviceKey)` - Registers all scanned services with a fixed service key
- `WithServiceKey(Func<Type, object?> selector)` - Registers services with dynamic keys based on a selector function

## Usage Examples

### Fixed Service Key

Register all scanned services with the same key:

```csharp
services.Scan(scan => scan
    .FromAssemblyOf<MyService>()
    .AddClasses()
    .AsImplementedInterfaces()
    .WithServiceKey("my-key")
    .WithTransientLifetime());

// Resolve using the key
var service = provider.GetRequiredKeyedService<IMyService>("my-key");
```

### Dynamic Service Key

Use a selector function to assign different keys based on the implementation type:

```csharp
services.Scan(scan => scan
    .FromAssemblyOf<IRepository>()
    .AddClasses(c => c.AssignableTo<IRepository>())
    .AsImplementedInterfaces()
    .WithServiceKey(type => type.Name.Replace("Repository", ""))
    .WithScopedLifetime());

// Resolve specific repositories by key
var customerRepo = provider.GetRequiredKeyedService<IRepository>("Customer");
var orderRepo = provider.GetRequiredKeyedService<IRepository>("Order");
```