### PR TITLE
Add NuGet packaging and GitHub Packages upload to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,16 @@ jobs:
                   files: coverage.cobertura.xml
                   token: ${{ secrets.CODECOV_TOKEN }}
                   fail_ci_if_error: false
+
+            - name: Pack NuGet package
+              run: dotnet pack src/Scrutor/Scrutor.csproj --configuration Release --output ./artifacts
+
+            - name: Upload NuGet package artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: nuget-packages
+                  path: ./artifacts/*.nupkg
+
+            - name: Push to GitHub Packages
+              if: github.event_name == 'push' && startsWith(github.repository, 'khellang/')
+              run: dotnet nuget push ./artifacts/*.nupkg --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate


### PR DESCRIPTION
Add three new steps to the CI workflow:

1. Pack NuGet package:
   - Builds Release configuration of Scrutor.csproj
   - Outputs to ./artifacts directory
   - Creates deterministic .nupkg and .snupkg files

2. Upload NuGet package artifact:
   - Makes packages available as GitHub Actions artifacts
   - Useful for debugging and manual downloads
   - Preserved for workflow retention period

3. Push to GitHub Packages:
   - Only runs on push events (not pull requests)
   - Only runs on khellang/* repositories
   - Uses GITHUB_TOKEN for authentication
   - Skips duplicates to avoid errors on re-runs
   - Publishes to GitHub's NuGet feed

This enables automatic package distribution on every push while maintaining deterministic, reproducible builds.